### PR TITLE
feat: redesign all CV pages with Refined Original aesthetic

### DIFF
--- a/en.html
+++ b/en.html
@@ -17,27 +17,44 @@
     <link rel="icon" type="image/png" href="favicon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700;900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700;900&family=Roboto+Slab:wght@400;500;600;700&display=swap" rel="stylesheet">
 
     <style>
-        /* ======= Custom Properties ======= */
         :root {
-            --color-primary: #42A8C0;
-            --color-primary-dark: #2d7788;
-            --color-primary-darker: #1a454f;
-            --color-text: #545E6C;
-            --color-text-dark: #3F4650;
-            --color-text-muted: #97AAC3;
-            --color-bg: #f5f5f5;
-            --color-white: #fff;
-            --color-skill-bar: #7bc2d3;
-            --color-sidebar-overlay: rgba(0, 0, 0, 0.2);
-            --color-sidebar-muted: rgba(255, 255, 255, 0.6);
-            --sidebar-width: 240px;
-            --max-width: 960px;
+            --color-primary: #2A9D8F;
+            --color-primary-dark: #1E7A6E;
+            --color-primary-darker: #145650;
+            --color-text: #3B4252;
+            --color-text-dark: #2E3440;
+            --color-text-muted: #8B95A5;
+            --color-bg: #F5F5F5;
+            --color-white: #FFFFFF;
+            --color-skill-bar: #6EC6B8;
+            --color-sidebar: #264653;
+            --color-sidebar-overlay: rgba(0, 0, 0, 0.15);
+            --color-sidebar-muted: rgba(255, 255, 255, 0.55);
+            --color-donate-bg: #E76F51;
+            --color-donate-hover: #D45A3C;
+            --sidebar-width: 250px;
+            --max-width: 980px;
         }
 
-        /* ======= Reset & Base ======= */
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --color-bg: #1A1D24;
+                --color-white: #22262E;
+                --color-text: #D8DEE9;
+                --color-text-dark: #ECEFF4;
+                --color-text-muted: #6B7894;
+                --color-primary: #56C4B4;
+                --color-primary-dark: #7AD4C8;
+                --color-primary-darker: #A0E4DA;
+                --color-skill-bar: #56C4B4;
+                --color-sidebar: #161920;
+                --color-sidebar-overlay: rgba(0, 0, 0, 0.3);
+            }
+        }
+
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
         body {
@@ -45,43 +62,43 @@
             color: var(--color-text);
             background: var(--color-bg);
             font-size: 14px;
-            line-height: 1.5;
+            line-height: 1.6;
             padding: 30px;
             -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
         }
 
-        h1, h2, h3, h4, h5, h6 { font-weight: 700; }
-        a { color: var(--color-primary-dark); transition: color 0.3s; }
+        h1, h2, h3 { font-family: 'Roboto Slab', 'Georgia', serif; }
+        a { color: var(--color-primary-dark); text-decoration: none; transition: color 0.2s; }
         a:hover { color: var(--color-primary-darker); }
         ul { list-style: none; }
         img { max-width: 100%; height: auto; }
 
-        /* ======= Layout ======= */
         .cv-wrapper {
             max-width: var(--max-width);
             margin: 0 auto;
             display: grid;
             grid-template-columns: 1fr var(--sidebar-width);
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+            overflow: hidden;
         }
 
-        /* ======= Main Content ======= */
         .main-content {
             background: var(--color-white);
-            padding: 60px;
+            padding: 52px 56px;
             order: -1;
         }
 
-        .section { margin-bottom: 60px; page-break-inside: avoid; }
+        .section { margin-bottom: 48px; page-break-inside: avoid; }
         .section:last-child { margin-bottom: 0; }
 
         .section-title {
             text-transform: uppercase;
-            font-size: 20px;
-            font-weight: 500;
+            font-size: 18px;
+            font-weight: 600;
             color: var(--color-primary-dark);
             margin-bottom: 20px;
+            padding-bottom: 10px;
+            border-bottom: 2px solid var(--color-primary);
             display: flex;
             align-items: center;
             gap: 10px;
@@ -90,7 +107,7 @@
         .section-icon {
             width: 30px;
             height: 30px;
-            background: var(--color-primary-dark);
+            background: var(--color-primary);
             border-radius: 50%;
             display: inline-flex;
             align-items: center;
@@ -98,18 +115,18 @@
             flex-shrink: 0;
         }
 
-        .section-icon svg {
-            width: 14px;
-            height: 14px;
-            fill: var(--color-white);
-        }
+        .section-icon svg { width: 14px; height: 14px; fill: #fff; }
 
-        /* ======= Summary ======= */
-        .summary p { margin-bottom: 1em; }
+        .summary { font-size: 14px; line-height: 1.75; color: var(--color-text); }
+        .summary p { margin-bottom: 0.9em; }
         .summary p:last-child { margin-bottom: 0; }
+        .summary strong { color: var(--color-text-dark); font-weight: 700; }
 
-        /* ======= Experience ======= */
-        .experience-item { margin-bottom: 30px; }
+        .experience-item {
+            margin-bottom: 28px;
+            padding-left: 16px;
+            border-left: 3px solid var(--color-primary);
+        }
         .experience-item:last-child { margin-bottom: 0; }
 
         .experience-header {
@@ -117,307 +134,191 @@
             justify-content: space-between;
             align-items: baseline;
             margin-bottom: 2px;
+            gap: 12px;
         }
 
         .job-title {
             color: var(--color-text-dark);
             font-size: 16px;
-            font-weight: 500;
+            font-weight: 600;
         }
 
         .time {
             color: var(--color-text-muted);
             white-space: nowrap;
-            margin-left: 10px;
+            font-size: 13px;
         }
 
         .company {
-            color: var(--color-text-muted);
-            margin-bottom: 10px;
-        }
-
-        .details p { margin-bottom: 0.8em; }
-        .details p:last-child { margin-bottom: 0; }
-        .details ul { list-style: disc; margin-left: 20px; margin-bottom: 0.8em; }
-        .details ul:last-child { margin-bottom: 0; }
-        .details li { margin-bottom: 0.3em; }
-
-        /* ======= Skills ======= */
-        .skill-item {
-            margin-bottom: 15px;
-            overflow: hidden;
-        }
-
-        .skill-name {
-            font-size: 14px;
-            font-weight: 700;
-            margin-bottom: 12px;
-        }
-
-        .skill-bar {
-            height: 12px;
-            background: var(--color-bg);
-            width: 100%;
-        }
-
-        .skill-bar-inner {
-            height: 12px;
-            background: var(--color-skill-bar);
-            width: 0;
-            animation: grow-bar 1s ease-out forwards;
-        }
-
-        @keyframes grow-bar {
-            to { width: var(--level); }
-        }
-
-        /* Technical skills list */
-        .tech-skills { margin-top: 30px; }
-        .tech-skills h3 {
-            font-size: 14px;
-            font-weight: 700;
-            color: var(--color-text-dark);
+            color: var(--color-primary-dark);
+            font-size: 13px;
+            font-weight: 500;
             margin-bottom: 8px;
         }
-        .tech-skills ul {
-            list-style: none;
-            margin-bottom: 12px;
+
+        .details { color: var(--color-text); font-size: 13px; line-height: 1.65; }
+        .details p { margin-bottom: 0.7em; }
+        .details p:last-child { margin-bottom: 0; }
+        .details ul { list-style: disc; margin-left: 18px; margin-bottom: 0.7em; }
+        .details ul:last-child { margin-bottom: 0; }
+        .details li { margin-bottom: 3px; }
+
+        .skill-item { margin-bottom: 15px; overflow: hidden; }
+        .skill-name { font-size: 14px; font-weight: 500; margin-bottom: 6px; color: var(--color-text-dark); }
+        .skill-bar { height: 10px; background: var(--color-bg); width: 100%; border-radius: 5px; }
+        .skill-bar-inner {
+            height: 10px;
+            background: var(--color-skill-bar);
+            border-radius: 5px;
+            width: 0;
+            animation: grow-bar 0.8s ease-out forwards;
         }
+        @keyframes grow-bar { to { width: var(--level); } }
+
+        .tech-skills { margin-top: 28px; }
+        .tech-skills h3 { font-size: 13px; font-weight: 600; color: var(--color-text-dark); margin-bottom: 6px; }
+        .tech-skills ul { list-style: none; margin-bottom: 12px; }
         .tech-skills li {
-            margin-bottom: 4px;
-            padding-left: 16px;
+            margin-bottom: 3px;
+            padding-left: 14px;
             position: relative;
+            font-size: 13px;
         }
         .tech-skills li::before {
             content: "·";
             position: absolute;
             left: 4px;
             font-weight: 700;
+            color: var(--color-primary);
         }
 
-        /* ======= Sidebar ======= */
         .sidebar {
-            background: var(--color-primary);
-            color: var(--color-white);
+            background: var(--color-sidebar);
+            color: #fff;
             min-height: 800px;
         }
 
-        .sidebar a { color: var(--color-white); text-decoration: none; }
-        .sidebar a:hover { text-decoration: underline; color: var(--color-white); }
+        .sidebar a { color: #fff; text-decoration: none; }
+        .sidebar a:hover { text-decoration: underline; }
 
-        /* Profile */
         .profile {
-            padding: 30px;
+            padding: 36px 28px 28px;
             background: var(--color-sidebar-overlay);
             text-align: center;
         }
 
         .profile-photo {
-            width: 120px;
-            height: 120px;
+            width: 115px;
+            height: 115px;
             border-radius: 50%;
-            margin-bottom: 15px;
+            margin-bottom: 16px;
+            border: 3px solid rgba(255,255,255,0.2);
         }
 
         .profile .name {
-            font-size: 32px;
-            font-weight: 900;
-            margin-bottom: 10px;
+            font-size: 24px;
+            font-weight: 700;
+            margin-bottom: 8px;
         }
 
         .profile .tagline {
             color: var(--color-sidebar-muted);
-            font-size: 16px;
-            font-weight: 400;
+            font-size: 13px;
+            font-weight: 300;
         }
 
-        /* Sidebar blocks */
-        .sidebar-block {
-            padding: 30px;
-        }
-
-        .sidebar-block-title {
-            text-transform: uppercase;
-            font-size: 16px;
-            font-weight: 700;
-            margin-bottom: 15px;
-        }
-
-        /* Language toggle */
         .lang-toggle {
-            padding: 10px 30px;
+            padding: 10px 28px;
             text-align: center;
             font-size: 13px;
             font-weight: 500;
         }
+        .lang-toggle a { opacity: 0.6; }
+        .lang-toggle a:hover { opacity: 1; }
+        .lang-toggle .active { opacity: 1; font-weight: 700; cursor: default; }
 
-        .lang-toggle a {
-            opacity: 0.7;
-        }
-
-        .lang-toggle a:hover {
-            opacity: 1;
-        }
-
-        .lang-toggle .active {
-            opacity: 1;
+        .donate-banner { padding: 0; }
+        .donate-banner a {
+            display: block;
+            background: var(--color-donate-bg);
+            color: #fff;
             font-weight: 700;
+            font-size: 13px;
+            padding: 14px 28px;
+            text-align: center;
             text-decoration: none;
-            cursor: default;
+            transition: background 0.2s;
+        }
+        .donate-banner a:hover { background: var(--color-donate-hover); text-decoration: none; }
+
+        .sidebar-block { padding: 24px 28px; }
+        .sidebar-block-title {
+            text-transform: uppercase;
+            font-size: 13px;
+            font-weight: 700;
+            margin-bottom: 14px;
+            letter-spacing: 0.5px;
         }
 
-        /* Contact */
         .contact-item {
-            margin-bottom: 15px;
+            margin-bottom: 12px;
             display: flex;
             align-items: center;
             gap: 8px;
             word-break: break-word;
+            font-size: 13px;
         }
-
         .contact-item:last-child { margin-bottom: 0; }
+        .contact-icon { width: 16px; height: 16px; flex-shrink: 0; fill: rgba(255,255,255,0.7); }
 
-        .contact-icon {
-            width: 18px;
-            height: 18px;
-            flex-shrink: 0;
-            fill: var(--color-white);
-        }
-
-        /* Education */
-        .education-item { margin-bottom: 15px; }
+        .education-item { margin-bottom: 12px; }
         .education-item:last-child { margin-bottom: 0; }
+        .degree { font-size: 14px; font-weight: 700; margin-bottom: 4px; }
+        .school { color: var(--color-sidebar-muted); font-size: 12px; }
+        .education-dates { color: var(--color-sidebar-muted); font-size: 12px; }
 
-        .degree {
-            font-size: 14px;
-            font-weight: 700;
-            margin-bottom: 5px;
-        }
-
-        .school {
-            color: var(--color-sidebar-muted);
-            font-weight: 500;
-            font-size: 13px;
-        }
-
-        .education-dates {
-            color: var(--color-sidebar-muted);
-            font-weight: 500;
-            font-size: 13px;
-        }
-
-        /* Languages */
-        .lang-item { margin-bottom: 10px; }
+        .lang-item { margin-bottom: 8px; font-size: 13px; }
         .lang-item:last-child { margin-bottom: 0; }
         .lang-level { color: var(--color-sidebar-muted); }
 
-        /* Interests */
-        .interest-item { margin-bottom: 10px; }
+        .interest-item { margin-bottom: 8px; font-size: 13px; }
         .interest-item:last-child { margin-bottom: 0; }
 
-        /* ======= Donate Banner ======= */
-        .donate-banner {
-            padding: 0;
-        }
-
-        .donate-banner a {
-            display: block;
-            background: #FBB03B;
-            color: #000080;
-            font-weight: 700;
-            text-decoration: none;
-            font-size: 14px;
-            padding: 14px 30px;
-            text-align: center;
-            transition: background 0.3s;
-        }
-
-        .donate-banner a:hover {
-            background: #e09a2a;
-            text-decoration: none;
-            color: #000080;
-        }
-
-        /* ======= Footer ======= */
         .cv-footer {
             max-width: var(--max-width);
             margin: 0 auto;
-            padding: 30px;
-            padding-top: 60px;
+            padding: 28px 20px;
+            padding-top: 48px;
             text-align: center;
-            color: var(--color-text);
-            font-size: 13px;
-            line-height: 1.6;
+            color: var(--color-text-muted);
+            font-size: 12px;
+            line-height: 1.8;
         }
+        .cv-footer a { font-weight: 500; color: var(--color-primary-dark); }
 
-        .cv-footer a {
-            font-weight: 500;
-        }
-
-        /* ======= Responsive ======= */
         @media (max-width: 767px) {
-            body { padding: 15px; }
-
-            .cv-wrapper {
-                grid-template-columns: 1fr;
-            }
-
-            .sidebar {
-                min-height: auto;
-                order: -1;
-            }
-
-            .main-content {
-                padding: 30px;
-                order: 0;
-            }
-
-            .experience-header {
-                flex-direction: column;
-            }
-
-            .time {
-                margin-left: 0;
-                margin-top: 4px;
-            }
+            body { padding: 12px; }
+            .cv-wrapper { grid-template-columns: 1fr; }
+            .sidebar { min-height: auto; order: -1; }
+            .main-content { padding: 32px 24px; order: 0; }
+            .experience-header { flex-direction: column; gap: 2px; }
         }
 
         @media (min-width: 992px) {
-            .skill-item {
-                display: flex;
-                align-items: center;
-                gap: 0;
-            }
-
-            .skill-name {
-                width: 30%;
-                flex-shrink: 0;
-                margin-bottom: 0;
-            }
-
-            .skill-bar {
-                width: 70%;
-            }
+            .skill-item { display: flex; align-items: center; gap: 0; }
+            .skill-name { width: 30%; flex-shrink: 0; margin-bottom: 0; }
+            .skill-bar { width: 70%; }
         }
 
-        /* ======= Print ======= */
         @media print {
             body { padding: 0; background: white; font-size: 12px; }
-
-            .cv-wrapper {
-                box-shadow: none;
-                max-width: 100%;
-            }
-
-            .sidebar { background: var(--color-primary) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .profile { background: var(--color-sidebar-overlay) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .skill-bar { background: var(--color-bg) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .skill-bar-inner { background: var(--color-skill-bar) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; animation: none; width: var(--level) !important; }
-
-            .section { margin-bottom: 30px; }
-            .main-content { padding: 30px; }
-            .cv-footer { padding-top: 20px; }
-
+            .cv-wrapper { box-shadow: none; max-width: 100%; }
+            .main-content { background: white; }
+            .sidebar { background: var(--color-sidebar) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            .skill-bar { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            .skill-bar-inner { -webkit-print-color-adjust: exact; print-color-adjust: exact; animation: none; width: var(--level) !important; }
+            .section { margin-bottom: 24px; }
+            .main-content { padding: 28px; }
             a { text-decoration: none !important; }
             .donate-banner { display: none; }
         }
@@ -431,9 +332,7 @@
         <!-- Career Profile -->
         <section class="section">
             <h2 class="section-title">
-                <span class="section-icon">
-                    <svg viewBox="0 0 448 512"><path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512H418.3c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304H178.3z"/></svg>
-                </span>
+                <span class="section-icon"><svg viewBox="0 0 448 512"><path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512H418.3c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304H178.3z"/></svg></span>
                 Who am I
             </h2>
             <div class="summary">
@@ -447,9 +346,7 @@
         <!-- Experience -->
         <section class="section">
             <h2 class="section-title">
-                <span class="section-icon">
-                    <svg viewBox="0 0 512 512"><path d="M184 48H328c4.4 0 8 3.6 8 8V96H176V56c0-4.4 3.6-8 8-8zm-56 8V96H64C28.7 96 0 124.7 0 160v96H192 320 512V160c0-35.3-28.7-64-64-64H384V56c0-30.9-25.1-56-56-56H184c-30.9 0-56 25.1-56 56zM512 288H320v32c0 17.7-14.3 32-32 32H224c-17.7 0-32-14.3-32-32V288H0V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V288z"/></svg>
-                </span>
+                <span class="section-icon"><svg viewBox="0 0 512 512"><path d="M184 48H328c4.4 0 8 3.6 8 8V96H176V56c0-4.4 3.6-8 8-8zm-56 8V96H64C28.7 96 0 124.7 0 160v96H192 320 512V160c0-35.3-28.7-64-64-64H384V56c0-30.9-25.1-56-56-56H184c-30.9 0-56 25.1-56 56zM512 288H320v32c0 17.7-14.3 32-32 32H224c-17.7 0-32-14.3-32-32V288H0V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V288z"/></svg></span>
                 Experience
             </h2>
 
@@ -461,16 +358,14 @@
                     <span class="time">May 2021 - April 2025</span>
                 </div>
                 <div class="company">Ledger</div>
-                <div class="details">
-                    <ul>
-                        <li>Designed and maintained production infrastructure for a cryptocurrency SaaS platform serving millions of users</li>
-                        <li>Implemented infrastructure-as-code practices using Terraform and policy-as-code frameworks</li>
-                        <li>Managed Kubernetes deployments on AWS EKS with Helm charts and ArgoCD/Spinnaker for continuous delivery</li>
-                        <li>Built comprehensive monitoring solutions with Prometheus and Grafana</li>
-                        <li>Optimized CI/CD pipelines achieving lower failure rates and faster deployment cycles</li>
-                        <li>Coordinated cross-functional collaboration between development, security, and operations teams</li>
-                    </ul>
-                </div>
+                <div class="details"><ul>
+                    <li>Designed and maintained production infrastructure for a cryptocurrency SaaS platform serving millions of users</li>
+                    <li>Implemented infrastructure-as-code practices using Terraform and policy-as-code frameworks</li>
+                    <li>Managed Kubernetes deployments on AWS EKS with Helm charts and ArgoCD/Spinnaker for continuous delivery</li>
+                    <li>Built comprehensive monitoring solutions with Prometheus and Grafana</li>
+                    <li>Optimized CI/CD pipelines achieving lower failure rates and faster deployment cycles</li>
+                    <li>Coordinated cross-functional collaboration between development, security, and operations teams</li>
+                </ul></div>
             </div>
 
             <div class="experience-item">
@@ -479,14 +374,12 @@
                     <span class="time">August 2019 - May 2021</span>
                 </div>
                 <div class="company">Ledger</div>
-                <div class="details">
-                    <ul>
-                        <li>Managed full AWS infrastructure including EKS clusters, networking, and security configurations</li>
-                        <li>Deployed and maintained Kubernetes workloads using Helm</li>
-                        <li>Automated infrastructure provisioning with Terraform, Chef, and Ansible/SaltStack</li>
-                        <li>Collaborated with development teams to establish DevOps workflows and deployment standards</li>
-                    </ul>
-                </div>
+                <div class="details"><ul>
+                    <li>Managed full AWS infrastructure including EKS clusters, networking, and security configurations</li>
+                    <li>Deployed and maintained Kubernetes workloads using Helm</li>
+                    <li>Automated infrastructure provisioning with Terraform, Chef, and Ansible/SaltStack</li>
+                    <li>Collaborated with development teams to establish DevOps workflows and deployment standards</li>
+                </ul></div>
             </div>
 
             <div class="experience-item">
@@ -495,13 +388,11 @@
                     <span class="time">November 2022 - August 2025</span>
                 </div>
                 <div class="company">Astroquirks</div>
-                <div class="details">
-                    <ul>
-                        <li>Built validator infrastructure for Tendermint/Cosmos-based blockchains (Osmosis, Stargaze)</li>
-                        <li>Designed full technical stack for high-availability blockchain node operation with 99.9% uptime</li>
-                        <li>Implemented monitoring, alerting, and auto-recovery systems</li>
-                    </ul>
-                </div>
+                <div class="details"><ul>
+                    <li>Built validator infrastructure for Tendermint/Cosmos-based blockchains (Osmosis, Stargaze)</li>
+                    <li>Designed full technical stack for high-availability blockchain node operation with 99.9% uptime</li>
+                    <li>Implemented monitoring, alerting, and auto-recovery systems</li>
+                </ul></div>
             </div>
 
             <div class="experience-item">
@@ -510,14 +401,12 @@
                     <span class="time">October 2013 - October 2018</span>
                 </div>
                 <div class="company">PortaOne, Kyiv</div>
-                <div class="details">
-                    <ul>
-                        <li>Led technical support team providing L3/L4 support for VoIP billing systems in production environments</li>
-                        <li>Established processes and standards for collaboration between Development, QA, and Product Management</li>
-                        <li>Managed complex software deployments and system integrations for global enterprise clients</li>
-                        <li>Reduced employee turnover through process optimization and continuous growth systems</li>
-                    </ul>
-                </div>
+                <div class="details"><ul>
+                    <li>Led technical support team providing L3/L4 support for VoIP billing systems in production environments</li>
+                    <li>Established processes and standards for collaboration between Development, QA, and Product Management</li>
+                    <li>Managed complex software deployments and system integrations for global enterprise clients</li>
+                    <li>Reduced employee turnover through process optimization and continuous growth systems</li>
+                </ul></div>
             </div>
 
             <div class="experience-item">
@@ -526,13 +415,11 @@
                     <span class="time">October 2008 - October 2013</span>
                 </div>
                 <div class="company">PortaOne, Kyiv</div>
-                <div class="details">
-                    <ul>
-                        <li>Advanced Linux/FreeBSD administration and troubleshooting of geo-redundant clustered systems</li>
-                        <li>Executed complex maintenance scenarios, software upgrades, and system migrations with minimal downtime</li>
-                        <li>Provided on-site technical consulting and installations for clients worldwide</li>
-                    </ul>
-                </div>
+                <div class="details"><ul>
+                    <li>Advanced Linux/FreeBSD administration and troubleshooting of geo-redundant clustered systems</li>
+                    <li>Executed complex maintenance scenarios, software upgrades, and system migrations with minimal downtime</li>
+                    <li>Provided on-site technical consulting and installations for clients worldwide</li>
+                </ul></div>
             </div>
 
             <div class="experience-item">
@@ -561,9 +448,7 @@
         <!-- Skills -->
         <section class="section">
             <h2 class="section-title">
-                <span class="section-icon">
-                    <svg viewBox="0 0 512 512"><path d="M156.6 384.9L125.7 354c-8.5-8.5-11.5-20.8-7.7-32.2c3-8.9 7.7-17.4 13.9-25.2L48.5 213c-11.3-11.3-11.3-29.6 0-40.8l57.4-56.7c11.3-11.3 29.5-11.3 40.8 0l83.5 83.5c7.8-6.1 16.3-10.8 25.2-13.7c11.4-3.9 23.7-.8 32.2 7.7l30.9 30.9c5.7 5.7 8.7 13.5 8.4 21.6c19.4 14.6 34.5 34.4 43.5 57.5H480c17.7 0 32-14.3 32-32V64c0-17.7-14.3-32-32-32H64C46.3 32 32 46.3 32 64V352c0 17.7 14.3 32 32 32h92.5zM256 224a64 64 0 1 1 0 128 64 64 0 1 1 0-128zm-43.3 203.3l-20.6-20.6-76.2 76.2c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l76.2-76.2-20.6-20.6c-1.3-1.3-2.5-2.7-3.6-4.1zM393.4 307.2l-39.6-39.6c-3.3 5.7-7.2 11-11.7 15.5s-9.9 8.4-15.5 11.7l39.6 39.6 27.1-27.1z"/></svg>
-                </span>
+                <span class="section-icon"><svg viewBox="0 0 512 512"><path d="M156.6 384.9L125.7 354c-8.5-8.5-11.5-20.8-7.7-32.2c3-8.9 7.7-17.4 13.9-25.2L48.5 213c-11.3-11.3-11.3-29.6 0-40.8l57.4-56.7c11.3-11.3 29.5-11.3 40.8 0l83.5 83.5c7.8-6.1 16.3-10.8 25.2-13.7c11.4-3.9 23.7-.8 32.2 7.7l30.9 30.9c5.7 5.7 8.7 13.5 8.4 21.6c19.4 14.6 34.5 34.4 43.5 57.5H480c17.7 0 32-14.3 32-32V64c0-17.7-14.3-32-32-32H64C46.3 32 32 46.3 32 64V352c0 17.7 14.3 32 32 32h92.5zM256 224a64 64 0 1 1 0 128 64 64 0 1 1 0-128zm-43.3 203.3l-20.6-20.6-76.2 76.2c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l76.2-76.2-20.6-20.6c-1.3-1.3-2.5-2.7-3.6-4.1zM393.4 307.2l-39.6-39.6c-3.3 5.7-7.2 11-11.7 15.5s-9.9 8.4-15.5 11.7l39.6 39.6 27.1-27.1z"/></svg></span>
                 Skills &amp; Proficiency
             </h2>
 
@@ -571,22 +456,18 @@
                 <h3 class="skill-name">Communication</h3>
                 <div class="skill-bar"><div class="skill-bar-inner" style="--level: 98%"></div></div>
             </div>
-
             <div class="skill-item">
                 <h3 class="skill-name">Problem Solving</h3>
                 <div class="skill-bar"><div class="skill-bar-inner" style="--level: 87%"></div></div>
             </div>
-
             <div class="skill-item">
                 <h3 class="skill-name">Management</h3>
                 <div class="skill-bar"><div class="skill-bar-inner" style="--level: 97%"></div></div>
             </div>
-
             <div class="skill-item">
                 <h3 class="skill-name">Analytical</h3>
                 <div class="skill-bar"><div class="skill-bar-inner" style="--level: 95%"></div></div>
             </div>
-
             <div class="skill-item">
                 <h3 class="skill-name">Technical</h3>
                 <div class="skill-bar"><div class="skill-bar-inner" style="--level: 75%"></div></div>
@@ -594,73 +475,37 @@
 
             <div class="tech-skills">
                 <h3>Cloud & Container Orchestration</h3>
-                <ul>
-                    <li>Kubernetes (EKS, RBAC, NetworkPolicy, ExternalSecrets), AWS (EC2, EKS, S3, CloudFormation), Docker</li>
-                </ul>
+                <ul><li>Kubernetes (EKS, RBAC, NetworkPolicy, ExternalSecrets), AWS (EC2, EKS, S3, CloudFormation), Docker</li></ul>
                 <h3>Infrastructure as Code</h3>
-                <ul>
-                    <li>Terraform, Helm, Chef, Ansible/SaltStack</li>
-                </ul>
+                <ul><li>Terraform, Helm, Chef, Ansible/SaltStack</li></ul>
                 <h3>CI/CD & GitOps</h3>
-                <ul>
-                    <li>ArgoCD, Spinnaker, GitHub Actions</li>
-                </ul>
+                <ul><li>ArgoCD, Spinnaker, GitHub Actions</li></ul>
                 <h3>Monitoring & Observability</h3>
-                <ul>
-                    <li>Prometheus, Grafana, logging, tracing, alerting, RED/DORA metrics</li>
-                </ul>
+                <ul><li>Prometheus, Grafana, logging, tracing, alerting, RED/DORA metrics</li></ul>
                 <h3>Security</h3>
-                <ul>
-                    <li>Vault, OAuth2, OIDC</li>
-                </ul>
+                <ul><li>Vault, OAuth2, OIDC</li></ul>
                 <h3>Systems Administration</h3>
-                <ul>
-                    <li>Linux (Ubuntu, RHEL, LFS), FreeBSD, networking, performance tuning</li>
-                </ul>
+                <ul><li>Linux (Ubuntu, RHEL, LFS), FreeBSD, networking, performance tuning</li></ul>
             </div>
         </section>
 
     </main>
 
     <aside class="sidebar">
-        <!-- Profile -->
         <div class="profile">
             <img class="profile-photo" src="profile.png" alt="Iurii Klekovkin" width="120" height="120">
             <h1 class="name">Iurii Klekovkin</h1>
             <p class="tagline">SRE · DevOps · Team Management</p>
         </div>
-
-        <!-- Language toggle -->
-        <div class="lang-toggle">
-            <a href="index.html">UA</a> | <span class="active">EN</span>
-        </div>
-
-        <!-- Donate Banner -->
-        <div class="donate-banner">
-            <a href="donate.html">Support UAF / Підтримати ЗСУ</a>
-        </div>
-
-        <!-- Contact -->
+        <div class="lang-toggle"><a href="index.html">UA</a> | <span class="active">EN</span></div>
+        <div class="donate-banner"><a href="donate.html">Support UAF / Підтримати ЗСУ</a></div>
         <div class="sidebar-block">
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 512 512"><path d="M48 64C21.5 64 0 85.5 0 112c0 15.1 7.1 29.3 19.2 38.4L236.8 313.6c11.4 8.5 27 8.5 38.4 0L492.8 150.4c12.1-9.1 19.2-23.3 19.2-38.4c0-26.5-21.5-48-48-48H48zM0 176V384c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V176L294.4 339.2c-22.8 17.1-54 17.1-76.8 0L0 176z"/></svg>
-                <a href="mailto:iurii@klekovkin.com.ua">iurii@klekovkin.com.ua</a>
-            </div>
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 512 512"><path d="M164.9 24.6c-7.7-18.6-28-28.5-47.4-23.2l-88 24C12.1 30.2 0 46 0 64C0 311.4 200.6 512 448 512c18 0 33.8-12.1 38.6-29.5l24-88c5.3-19.4-4.6-39.7-23.2-47.4l-96-40c-16.3-6.8-35.2-2.1-46.3 11.6L304.7 368C234.3 334.7 177.3 277.7 144 207.3L193.3 167c13.7-11.2 18.4-30 11.6-46.3l-40-96z"/></svg>
-                <a href="tel:+380937791847">+380 93 779 1847</a>
-            </div>
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 448 512"><path d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg>
-                <a href="https://www.linkedin.com/in/klekovkin">in/klekovkin</a>
-            </div>
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 496 512"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.8-14.9-112.8-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/></svg>
-                <a href="https://github.com/depomytymoped">depomytymoped</a>
-            </div>
+            <h2 class="sidebar-block-title">Contact</h2>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 512 512"><path d="M48 64C21.5 64 0 85.5 0 112c0 15.1 7.1 29.3 19.2 38.4L236.8 313.6c11.4 8.5 27 8.5 38.4 0L492.8 150.4c12.1-9.1 19.2-23.3 19.2-38.4c0-26.5-21.5-48-48-48H48zM0 176V384c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V176L294.4 339.2c-22.8 17.1-54 17.1-76.8 0L0 176z"/></svg><a href="mailto:iurii@klekovkin.com.ua">iurii@klekovkin.com.ua</a></div>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 512 512"><path d="M164.9 24.6c-7.7-18.6-28-28.5-47.4-23.2l-88 24C12.1 30.2 0 46 0 64C0 311.4 200.6 512 448 512c18 0 33.8-12.1 38.6-29.5l24-88c5.3-19.4-4.6-39.7-23.2-47.4l-96-40c-16.3-6.8-35.2-2.1-46.3 11.6L304.7 368C234.3 334.7 177.3 277.7 144 207.3L193.3 167c13.7-11.2 18.4-30 11.6-46.3l-40-96z"/></svg><a href="tel:+380937791847">+380 93 779 1847</a></div>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 448 512"><path d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg><a href="https://www.linkedin.com/in/klekovkin">in/klekovkin</a></div>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 496 512"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.8-14.9-112.8-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/></svg><a href="https://github.com/depomytymoped">depomytymoped</a></div>
         </div>
-
-        <!-- Education -->
         <div class="sidebar-block">
             <h2 class="sidebar-block-title">Education</h2>
             <div class="education-item">
@@ -669,16 +514,12 @@
                 <div class="education-dates">2001 - 2019</div>
             </div>
         </div>
-
-        <!-- Languages -->
         <div class="sidebar-block">
             <h2 class="sidebar-block-title">Languages</h2>
             <div class="lang-item">Ukrainian <span class="lang-level">(Native)</span></div>
             <div class="lang-item">English <span class="lang-level">(Professional)</span></div>
             <div class="lang-item">Russian <span class="lang-level">(Beginner)</span></div>
         </div>
-
-        <!-- Interests -->
         <div class="sidebar-block">
             <h2 class="sidebar-block-title">Interests</h2>
             <div class="interest-item">Continuous growth</div>

--- a/index.html
+++ b/index.html
@@ -17,81 +17,164 @@
     <link rel="icon" type="image/png" href="favicon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700;900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800;900&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 
     <style>
-        /* ======= Custom Properties ======= */
+        /* ===== Light theme (default) ===== */
         :root {
-            --color-primary: #42A8C0;
-            --color-primary-dark: #2d7788;
-            --color-primary-darker: #1a454f;
-            --color-text: #545E6C;
-            --color-text-dark: #3F4650;
-            --color-text-muted: #97AAC3;
-            --color-bg: #f5f5f5;
-            --color-white: #fff;
-            --color-skill-bar: #7bc2d3;
-            --color-sidebar-overlay: rgba(0, 0, 0, 0.2);
-            --color-sidebar-muted: rgba(255, 255, 255, 0.6);
-            --sidebar-width: 240px;
-            --max-width: 960px;
+            --bg: #F0EDE6;
+            --surface: #FAF8F4;
+            --sidebar-bg: #1B2838;
+            --sidebar-text: #D6DDE8;
+            --sidebar-muted: rgba(214,221,232,0.5);
+            --sidebar-divider: rgba(255,255,255,0.08);
+            --text: #2C3340;
+            --text-secondary: #5A6270;
+            --text-muted: #8D95A2;
+            --accent: #2D8CFF;
+            --accent-hover: #1A6FD4;
+            --accent-dim: rgba(45,140,255,0.08);
+            --donate-bg: #E55934;
+            --donate-hover: #C94A2A;
+            --grid-line: rgba(45,140,255,0.07);
+            --grid-dot: rgba(45,140,255,0.12);
+            --section-line: rgba(45,140,255,0.18);
+            --section-dot: var(--accent);
+            --ruler-bg: #E8E4DC;
+            --ruler-fill: var(--accent);
+            --ruler-mark: rgba(45,140,255,0.25);
+            --card-shadow: 0 1px 3px rgba(0,0,0,0.06);
+            --sidebar-stripe: rgba(255,255,255,0.03);
+            --sidebar-photo-ring: rgba(45,140,255,0.5);
+            --sidebar-link: #7EB8FF;
+            --sidebar-link-hover: #fff;
+            --max-width: 1000px;
+            --sidebar-width: 260px;
         }
 
-        /* ======= Reset & Base ======= */
+        /* ===== Dark theme ===== */
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg: #0E1218;
+                --surface: #161B24;
+                --sidebar-bg: #0A0E14;
+                --sidebar-text: #C5CDD8;
+                --sidebar-muted: rgba(197,205,216,0.4);
+                --sidebar-divider: rgba(255,255,255,0.06);
+                --text: #D6DDE8;
+                --text-secondary: #8D97A8;
+                --text-muted: #5A6475;
+                --accent: #5BA3FF;
+                --accent-hover: #7DB8FF;
+                --accent-dim: rgba(91,163,255,0.08);
+                --donate-bg: #E55934;
+                --donate-hover: #FF6B42;
+                --grid-line: rgba(91,163,255,0.04);
+                --grid-dot: rgba(91,163,255,0.08);
+                --section-line: rgba(91,163,255,0.12);
+                --section-dot: var(--accent);
+                --ruler-bg: #1E2530;
+                --ruler-fill: var(--accent);
+                --ruler-mark: rgba(91,163,255,0.2);
+                --card-shadow: 0 1px 4px rgba(0,0,0,0.3);
+                --sidebar-stripe: rgba(255,255,255,0.015);
+                --sidebar-photo-ring: rgba(91,163,255,0.4);
+                --sidebar-link: #7EB8FF;
+                --sidebar-link-hover: #fff;
+            }
+        }
+
+        /* ===== Reset ===== */
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
         body {
-            font-family: 'Roboto', system-ui, -apple-system, sans-serif;
-            color: var(--color-text);
-            background: var(--color-bg);
+            font-family: 'Source Sans 3', 'Segoe UI', system-ui, sans-serif;
+            color: var(--text);
+            background: var(--bg);
             font-size: 14px;
-            line-height: 1.5;
-            padding: 30px;
+            line-height: 1.6;
+            padding: 28px;
             -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
         }
 
-        h1, h2, h3, h4, h5, h6 { font-weight: 700; }
-        a { color: var(--color-primary-dark); transition: color 0.3s; }
-        a:hover { color: var(--color-primary-darker); }
+        h1, h2, h3 { font-family: 'Archivo', 'Arial Black', sans-serif; }
+        a { color: var(--accent); text-decoration: none; transition: color 0.2s; }
+        a:hover { color: var(--accent-hover); }
         ul { list-style: none; }
         img { max-width: 100%; height: auto; }
 
-        /* ======= Layout ======= */
+        /* ===== Grid paper background ===== */
         .cv-wrapper {
             max-width: var(--max-width);
             margin: 0 auto;
             display: grid;
             grid-template-columns: 1fr var(--sidebar-width);
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            box-shadow: var(--card-shadow);
+            overflow: hidden;
         }
 
-        /* ======= Main Content ======= */
+        /* ===== Main Content ===== */
         .main-content {
-            background: var(--color-white);
-            padding: 60px;
+            background: var(--surface);
+            padding: 52px 52px 52px 56px;
             order: -1;
+            position: relative;
+            background-image:
+                linear-gradient(var(--grid-line) 1px, transparent 1px),
+                linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
+            background-size: 24px 24px;
         }
 
-        .section { margin-bottom: 60px; page-break-inside: avoid; }
+        /* ===== Sections ===== */
+        .section {
+            margin-bottom: 48px;
+            page-break-inside: avoid;
+        }
         .section:last-child { margin-bottom: 0; }
 
+        /* Section title — annotation style */
         .section-title {
+            font-family: 'Archivo', sans-serif;
+            font-size: 13px;
+            font-weight: 700;
+            letter-spacing: 2.5px;
             text-transform: uppercase;
-            font-size: 20px;
-            font-weight: 500;
-            color: var(--color-primary-dark);
-            margin-bottom: 20px;
+            color: var(--accent);
+            margin-bottom: 24px;
+            padding-bottom: 14px;
+            position: relative;
             display: flex;
             align-items: center;
             gap: 10px;
         }
 
-        .section-icon {
-            width: 30px;
-            height: 30px;
-            background: var(--color-primary-dark);
+        /* Dashed line with circle marker */
+        .section-title::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            border-bottom: 1.5px dashed var(--section-line);
+        }
+
+        .section-title::before {
+            content: '';
+            position: absolute;
+            bottom: -4px;
+            left: 0;
+            width: 8px;
+            height: 8px;
             border-radius: 50%;
+            background: var(--section-dot);
+            z-index: 1;
+        }
+
+        .section-icon {
+            width: 26px;
+            height: 26px;
+            background: var(--accent);
+            border-radius: 4px;
             display: inline-flex;
             align-items: center;
             justify-content: center;
@@ -99,293 +182,423 @@
         }
 
         .section-icon svg {
-            width: 14px;
-            height: 14px;
-            fill: var(--color-white);
+            width: 13px;
+            height: 13px;
+            fill: #fff;
         }
 
-        /* ======= Summary ======= */
-        .summary p { margin-bottom: 1em; }
+        /* ===== Summary ===== */
+        .summary {
+            font-size: 14px;
+            line-height: 1.7;
+            color: var(--text-secondary);
+        }
+        .summary p { margin-bottom: 0.9em; }
         .summary p:last-child { margin-bottom: 0; }
+        .summary strong { color: var(--text); font-weight: 600; }
 
-        /* ======= Experience ======= */
-        .experience-item { margin-bottom: 30px; }
+        /* ===== Experience ===== */
+        .experience-item {
+            margin-bottom: 28px;
+            padding-left: 20px;
+            position: relative;
+        }
         .experience-item:last-child { margin-bottom: 0; }
+
+        /* Vertical timeline line */
+        .experience-item::before {
+            content: '';
+            position: absolute;
+            left: 0;
+            top: 6px;
+            bottom: -28px;
+            width: 1.5px;
+            background: repeating-linear-gradient(
+                to bottom,
+                var(--section-line) 0px,
+                var(--section-line) 4px,
+                transparent 4px,
+                transparent 8px
+            );
+        }
+        .experience-item:last-child::before { bottom: 0; }
+
+        /* Dot on the timeline */
+        .experience-item::after {
+            content: '';
+            position: absolute;
+            left: -3px;
+            top: 6px;
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: var(--surface);
+            border: 2px solid var(--accent);
+        }
 
         .experience-header {
             display: flex;
             justify-content: space-between;
             align-items: baseline;
             margin-bottom: 2px;
+            gap: 12px;
         }
 
         .job-title {
-            color: var(--color-text-dark);
-            font-size: 16px;
-            font-weight: 500;
+            font-family: 'Archivo', sans-serif;
+            color: var(--text);
+            font-size: 15px;
+            font-weight: 600;
         }
 
         .time {
-            color: var(--color-text-muted);
+            font-family: 'Archivo', sans-serif;
+            font-size: 12px;
+            font-weight: 500;
+            color: var(--text-muted);
             white-space: nowrap;
-            margin-left: 10px;
+            letter-spacing: 0.5px;
         }
 
         .company {
-            color: var(--color-text-muted);
-            margin-bottom: 10px;
+            font-size: 13px;
+            color: var(--accent);
+            font-weight: 500;
+            margin-bottom: 8px;
         }
 
-        .details p { margin-bottom: 0.8em; }
+        .details { color: var(--text-secondary); font-size: 13px; line-height: 1.65; }
+        .details p { margin-bottom: 0.7em; }
         .details p:last-child { margin-bottom: 0; }
-        .details ul { list-style: disc; margin-left: 20px; margin-bottom: 0.8em; }
+        .details ul { list-style: none; margin-bottom: 0.7em; }
         .details ul:last-child { margin-bottom: 0; }
-        .details li { margin-bottom: 0.3em; }
+        .details li {
+            margin-bottom: 4px;
+            padding-left: 16px;
+            position: relative;
+        }
+        .details li::before {
+            content: '';
+            position: absolute;
+            left: 2px;
+            top: 8px;
+            width: 6px;
+            height: 6px;
+            border: 1.5px solid var(--accent);
+            border-radius: 50%;
+        }
 
-        /* ======= Military Service (collapsible) ======= */
+        /* ===== Military toggle ===== */
         .military-toggle {
-            background: none;
-            border: 1px solid var(--color-primary);
-            color: var(--color-primary-dark);
-            font-family: inherit;
-            font-size: 14px;
-            font-weight: 500;
-            padding: 8px 16px;
+            font-family: 'Archivo', sans-serif;
+            background: var(--accent-dim);
+            border: 1.5px dashed var(--section-line);
+            color: var(--accent);
+            font-size: 13px;
+            font-weight: 600;
+            padding: 8px 18px;
             border-radius: 4px;
             cursor: pointer;
-            margin-bottom: 30px;
-            transition: background 0.2s, color 0.2s;
+            margin-bottom: 28px;
+            transition: background 0.2s, border-color 0.2s;
+            letter-spacing: 0.3px;
         }
 
         .military-toggle:hover {
-            background: var(--color-primary);
-            color: var(--color-white);
+            background: var(--accent);
+            border-color: var(--accent);
+            color: #fff;
         }
 
         .military-details {
             display: none;
-            margin-bottom: 30px;
+            margin-bottom: 28px;
         }
 
         .military-details.open {
             display: block;
         }
 
-        /* ======= Skills ======= */
+        /* ===== Skills — ruler style ===== */
         .skill-item {
-            margin-bottom: 15px;
-            overflow: hidden;
+            margin-bottom: 16px;
         }
 
         .skill-name {
-            font-size: 14px;
-            font-weight: 700;
-            margin-bottom: 12px;
+            font-family: 'Archivo', sans-serif;
+            font-size: 12px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            color: var(--text);
+            margin-bottom: 8px;
         }
 
-        .skill-bar {
-            height: 12px;
-            background: var(--color-bg);
-            width: 100%;
+        .skill-ruler {
+            height: 10px;
+            background: var(--ruler-bg);
+            position: relative;
+            border-radius: 2px;
+            overflow: hidden;
         }
 
-        .skill-bar-inner {
-            height: 12px;
-            background: var(--color-skill-bar);
+        /* Ruler tick marks */
+        .skill-ruler::before {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: repeating-linear-gradient(
+                90deg,
+                transparent 0px,
+                transparent 9px,
+                var(--ruler-mark) 9px,
+                var(--ruler-mark) 10px
+            );
+            z-index: 1;
+        }
+
+        .skill-ruler-fill {
+            height: 100%;
+            background: var(--ruler-fill);
             width: 0;
-            animation: grow-bar 1s ease-out forwards;
+            animation: growBar 0.8s ease-out forwards;
+            position: relative;
+            opacity: 0.7;
         }
 
-        @keyframes grow-bar {
+        @keyframes growBar {
             to { width: var(--level); }
         }
 
-        /* Technical skills list */
-        .tech-skills { margin-top: 30px; }
+        /* Tech skills */
+        .tech-skills { margin-top: 28px; }
         .tech-skills h3 {
-            font-size: 14px;
+            font-family: 'Archivo', sans-serif;
+            font-size: 11px;
             font-weight: 700;
-            color: var(--color-text-dark);
+            text-transform: uppercase;
+            letter-spacing: 1.5px;
+            color: var(--text-muted);
             margin-bottom: 8px;
         }
         .tech-skills ul {
             list-style: none;
-            margin-bottom: 12px;
+            margin-bottom: 14px;
         }
         .tech-skills li {
             margin-bottom: 4px;
             padding-left: 16px;
             position: relative;
+            font-size: 13px;
+            color: var(--text-secondary);
         }
         .tech-skills li::before {
-            content: "·";
+            content: '';
             position: absolute;
             left: 4px;
-            font-weight: 700;
+            top: 9px;
+            width: 4px;
+            height: 4px;
+            background: var(--accent);
+            border-radius: 1px;
+            transform: rotate(45deg);
         }
 
-        /* ======= Sidebar ======= */
+        /* ===== Sidebar ===== */
         .sidebar {
-            background: var(--color-primary);
-            color: var(--color-white);
+            background: var(--sidebar-bg);
+            color: var(--sidebar-text);
+            position: relative;
             min-height: 800px;
         }
 
-        .sidebar a { color: var(--color-white); text-decoration: none; }
-        .sidebar a:hover { text-decoration: underline; color: var(--color-white); }
+        /* Diagonal stripe pattern at top */
+        .sidebar::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 200px;
+            background: repeating-linear-gradient(
+                -45deg,
+                transparent,
+                transparent 8px,
+                var(--sidebar-stripe) 8px,
+                var(--sidebar-stripe) 9px
+            );
+            pointer-events: none;
+        }
+
+        .sidebar a { color: var(--sidebar-link); text-decoration: none; }
+        .sidebar a:hover { color: var(--sidebar-link-hover); text-decoration: underline; }
 
         /* Profile */
         .profile {
-            padding: 30px;
-            background: var(--color-sidebar-overlay);
+            padding: 36px 28px 28px;
             text-align: center;
+            position: relative;
+            z-index: 1;
         }
 
         .profile-photo {
-            width: 120px;
-            height: 120px;
+            width: 110px;
+            height: 110px;
             border-radius: 50%;
-            margin-bottom: 15px;
+            margin-bottom: 16px;
+            border: 3px solid var(--sidebar-photo-ring);
+            box-shadow: 0 0 0 6px rgba(45,140,255,0.1);
         }
 
         .profile .name {
-            font-size: 32px;
-            font-weight: 900;
-            margin-bottom: 10px;
+            font-family: 'Archivo', sans-serif;
+            font-size: 22px;
+            font-weight: 800;
+            letter-spacing: -0.3px;
+            margin-bottom: 6px;
+            color: #fff;
         }
 
         .profile .tagline {
-            color: var(--color-sidebar-muted);
-            font-size: 16px;
-            font-weight: 400;
-        }
-
-        /* Sidebar blocks */
-        .sidebar-block {
-            padding: 30px;
-        }
-
-        .sidebar-block-title {
-            text-transform: uppercase;
-            font-size: 16px;
-            font-weight: 700;
-            margin-bottom: 15px;
-        }
-
-        /* Language toggle */
-        .lang-toggle {
-            padding: 10px 30px;
-            text-align: center;
+            color: var(--sidebar-muted);
             font-size: 13px;
-            font-weight: 500;
+            font-weight: 400;
+            letter-spacing: 0.5px;
         }
 
-        .lang-toggle a {
-            opacity: 0.7;
+        /* Lang toggle */
+        .lang-toggle {
+            padding: 10px 28px;
+            text-align: center;
+            font-size: 12px;
+            font-weight: 600;
+            letter-spacing: 1px;
+            position: relative;
+            z-index: 1;
         }
 
-        .lang-toggle a:hover {
-            opacity: 1;
-        }
+        .lang-toggle a { opacity: 0.5; }
+        .lang-toggle a:hover { opacity: 1; text-decoration: none; }
 
         .lang-toggle .active {
             opacity: 1;
-            font-weight: 700;
+            color: #fff;
             text-decoration: none;
             cursor: default;
         }
 
-        /* Contact */
-        .contact-item {
-            margin-bottom: 15px;
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            word-break: break-word;
-        }
-
-        .contact-item:last-child { margin-bottom: 0; }
-
-        .contact-icon {
-            width: 18px;
-            height: 18px;
-            flex-shrink: 0;
-            fill: var(--color-white);
-        }
-
-        /* Education */
-        .education-item { margin-bottom: 15px; }
-        .education-item:last-child { margin-bottom: 0; }
-
-        .degree {
-            font-size: 14px;
-            font-weight: 700;
-            margin-bottom: 5px;
-        }
-
-        .school {
-            color: var(--color-sidebar-muted);
-            font-weight: 500;
-            font-size: 13px;
-        }
-
-        .education-dates {
-            color: var(--color-sidebar-muted);
-            font-weight: 500;
-            font-size: 13px;
-        }
-
-        /* Languages */
-        .lang-item { margin-bottom: 10px; }
-        .lang-item:last-child { margin-bottom: 0; }
-        .lang-level { color: var(--color-sidebar-muted); }
-
-        /* Interests */
-        .interest-item { margin-bottom: 10px; }
-        .interest-item:last-child { margin-bottom: 0; }
-
-        /* ======= Donate Banner ======= */
-        .donate-banner {
-            padding: 0;
-        }
+        /* Donate banner */
+        .donate-banner { padding: 0; position: relative; z-index: 1; }
 
         .donate-banner a {
             display: block;
-            background: #FBB03B;
-            color: #000080;
+            background: var(--donate-bg);
+            color: #fff;
+            font-family: 'Archivo', sans-serif;
             font-weight: 700;
-            text-decoration: none;
-            font-size: 14px;
-            padding: 14px 30px;
+            font-size: 13px;
+            padding: 14px 28px;
             text-align: center;
-            transition: background 0.3s;
+            text-decoration: none;
+            letter-spacing: 0.5px;
+            transition: background 0.2s;
         }
 
         .donate-banner a:hover {
-            background: #e09a2a;
+            background: var(--donate-hover);
+            color: #fff;
             text-decoration: none;
-            color: #000080;
         }
 
-        /* ======= Footer ======= */
+        /* Sidebar blocks */
+        .sidebar-block {
+            padding: 24px 28px;
+            border-top: 1px solid var(--sidebar-divider);
+            position: relative;
+            z-index: 1;
+        }
+
+        .sidebar-block-title {
+            font-family: 'Archivo', sans-serif;
+            font-size: 10px;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            color: var(--sidebar-muted);
+            margin-bottom: 14px;
+        }
+
+        /* Contact */
+        .contact-item {
+            margin-bottom: 12px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            word-break: break-word;
+            font-size: 13px;
+        }
+        .contact-item:last-child { margin-bottom: 0; }
+
+        .contact-icon {
+            width: 16px;
+            height: 16px;
+            flex-shrink: 0;
+            fill: var(--sidebar-muted);
+        }
+
+        /* Education */
+        .education-item { margin-bottom: 12px; }
+        .education-item:last-child { margin-bottom: 0; }
+
+        .degree {
+            font-family: 'Archivo', sans-serif;
+            font-size: 13px;
+            font-weight: 600;
+            margin-bottom: 3px;
+        }
+
+        .school {
+            color: var(--sidebar-muted);
+            font-size: 12px;
+        }
+
+        .education-dates {
+            color: var(--sidebar-muted);
+            font-size: 12px;
+        }
+
+        /* Languages */
+        .lang-item {
+            margin-bottom: 8px;
+            font-size: 13px;
+        }
+        .lang-item:last-child { margin-bottom: 0; }
+        .lang-level { color: var(--sidebar-muted); font-size: 12px; }
+
+        /* Interests */
+        .interest-item {
+            margin-bottom: 8px;
+            font-size: 13px;
+        }
+        .interest-item:last-child { margin-bottom: 0; }
+
+        /* ===== Footer ===== */
         .cv-footer {
             max-width: var(--max-width);
             margin: 0 auto;
-            padding: 30px;
-            padding-top: 60px;
+            padding: 28px 20px;
+            padding-top: 48px;
             text-align: center;
-            color: var(--color-text);
-            font-size: 13px;
-            line-height: 1.6;
+            color: var(--text-muted);
+            font-size: 12px;
+            line-height: 1.8;
         }
 
-        .cv-footer a {
-            font-weight: 500;
-        }
+        .cv-footer a { font-weight: 600; }
 
-        /* ======= Responsive ======= */
+        /* ===== Responsive ===== */
         @media (max-width: 767px) {
-            body { padding: 15px; }
+            body { padding: 12px; }
 
             .cv-wrapper {
                 grid-template-columns: 1fr;
@@ -396,18 +609,20 @@
                 order: -1;
             }
 
+            .sidebar::before { height: 120px; }
+
             .main-content {
-                padding: 30px;
+                padding: 32px 24px;
                 order: 0;
             }
 
             .experience-header {
                 flex-direction: column;
+                gap: 2px;
             }
 
             .time {
-                margin-left: 0;
-                margin-top: 4px;
+                margin-top: 2px;
             }
         }
 
@@ -419,17 +634,17 @@
             }
 
             .skill-name {
-                width: 30%;
+                width: 28%;
                 flex-shrink: 0;
                 margin-bottom: 0;
             }
 
-            .skill-bar {
-                width: 70%;
+            .skill-ruler {
+                width: 72%;
             }
         }
 
-        /* ======= Print ======= */
+        /* ===== Print ===== */
         @media print {
             body { padding: 0; background: white; font-size: 12px; }
 
@@ -438,14 +653,20 @@
                 max-width: 100%;
             }
 
-            .sidebar { background: var(--color-primary) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .profile { background: var(--color-sidebar-overlay) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .skill-bar { background: var(--color-bg) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .skill-bar-inner { background: var(--color-skill-bar) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; animation: none; width: var(--level) !important; }
+            .main-content {
+                background-image: none;
+                background: white;
+            }
 
-            .section { margin-bottom: 30px; }
-            .main-content { padding: 30px; }
-            .cv-footer { padding-top: 20px; }
+            .sidebar { background: var(--sidebar-bg) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            .sidebar::before { display: none; }
+            .profile-photo { border-color: #999 !important; box-shadow: none !important; }
+            .skill-ruler { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            .skill-ruler-fill { -webkit-print-color-adjust: exact; print-color-adjust: exact; animation: none; width: var(--level) !important; }
+
+            .section { margin-bottom: 28px; }
+            .main-content { padding: 28px; }
+            .cv-footer { padding-top: 16px; }
 
             a { text-decoration: none !important; }
             .donate-banner { display: none; }
@@ -619,27 +840,27 @@
 
             <div class="skill-item">
                 <h3 class="skill-name">Комунікація</h3>
-                <div class="skill-bar"><div class="skill-bar-inner" style="--level: 98%"></div></div>
+                <div class="skill-ruler"><div class="skill-ruler-fill" style="--level: 98%"></div></div>
             </div>
 
             <div class="skill-item">
                 <h3 class="skill-name">Вирішення проблем</h3>
-                <div class="skill-bar"><div class="skill-bar-inner" style="--level: 87%"></div></div>
+                <div class="skill-ruler"><div class="skill-ruler-fill" style="--level: 87%"></div></div>
             </div>
 
             <div class="skill-item">
                 <h3 class="skill-name">Управління</h3>
-                <div class="skill-bar"><div class="skill-bar-inner" style="--level: 97%"></div></div>
+                <div class="skill-ruler"><div class="skill-ruler-fill" style="--level: 97%"></div></div>
             </div>
 
             <div class="skill-item">
                 <h3 class="skill-name">Аналітика</h3>
-                <div class="skill-bar"><div class="skill-bar-inner" style="--level: 95%"></div></div>
+                <div class="skill-ruler"><div class="skill-ruler-fill" style="--level: 95%"></div></div>
             </div>
 
             <div class="skill-item">
                 <h3 class="skill-name">Технічний</h3>
-                <div class="skill-bar"><div class="skill-bar-inner" style="--level: 75%"></div></div>
+                <div class="skill-ruler"><div class="skill-ruler-fill" style="--level: 75%"></div></div>
             </div>
 
             <div class="tech-skills">
@@ -692,6 +913,7 @@
 
         <!-- Контакти -->
         <div class="sidebar-block">
+            <h2 class="sidebar-block-title">Контакти</h2>
             <div class="contact-item">
                 <svg class="contact-icon" viewBox="0 0 512 512"><path d="M48 64C21.5 64 0 85.5 0 112c0 15.1 7.1 29.3 19.2 38.4L236.8 313.6c11.4 8.5 27 8.5 38.4 0L492.8 150.4c12.1-9.1 19.2-23.3 19.2-38.4c0-26.5-21.5-48-48-48H48zM0 176V384c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V176L294.4 339.2c-22.8 17.1-54 17.1-76.8 0L0 176z"/></svg>
                 <a href="mailto:iurii@klekovkin.com.ua">iurii@klekovkin.com.ua</a>

--- a/index.html
+++ b/index.html
@@ -17,70 +17,43 @@
     <link rel="icon" type="image/png" href="favicon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800;900&family=Source+Sans+3:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700;900&family=Roboto+Slab:wght@400;500;600;700&display=swap" rel="stylesheet">
 
     <style>
-        /* ===== Light theme (default) ===== */
+        /* ===== Variables ===== */
         :root {
-            --bg: #F0EDE6;
-            --surface: #FAF8F4;
-            --sidebar-bg: #1B2838;
-            --sidebar-text: #D6DDE8;
-            --sidebar-muted: rgba(214,221,232,0.5);
-            --sidebar-divider: rgba(255,255,255,0.08);
-            --text: #2C3340;
-            --text-secondary: #5A6270;
-            --text-muted: #6B7280;
-            --accent: #2D8CFF;
-            --accent-hover: #1A6FD4;
-            --accent-dim: rgba(45,140,255,0.08);
-            --donate-bg: #C43E1A;
-            --donate-hover: #A83415;
-            --grid-line: rgba(45,140,255,0.07);
-            --grid-dot: rgba(45,140,255,0.12);
-            --section-line: rgba(45,140,255,0.18);
-            --section-dot: var(--accent);
-            --ruler-bg: #E8E4DC;
-            --ruler-fill: var(--accent);
-            --ruler-mark: rgba(45,140,255,0.25);
-            --card-shadow: 0 1px 3px rgba(0,0,0,0.06);
-            --sidebar-stripe: rgba(255,255,255,0.03);
-            --sidebar-photo-ring: rgba(45,140,255,0.5);
-            --sidebar-link: #7EB8FF;
-            --sidebar-link-hover: #fff;
-            --max-width: 1000px;
-            --sidebar-width: 260px;
+            --color-primary: #2A9D8F;
+            --color-primary-dark: #1E7A6E;
+            --color-primary-darker: #145650;
+            --color-text: #3B4252;
+            --color-text-dark: #2E3440;
+            --color-text-muted: #8B95A5;
+            --color-bg: #F5F5F5;
+            --color-white: #FFFFFF;
+            --color-skill-bar: #6EC6B8;
+            --color-sidebar: #264653;
+            --color-sidebar-overlay: rgba(0, 0, 0, 0.15);
+            --color-sidebar-muted: rgba(255, 255, 255, 0.55);
+            --color-donate-bg: #E76F51;
+            --color-donate-hover: #D45A3C;
+            --sidebar-width: 250px;
+            --max-width: 980px;
         }
 
         /* ===== Dark theme ===== */
         @media (prefers-color-scheme: dark) {
             :root {
-                --bg: #0E1218;
-                --surface: #161B24;
-                --sidebar-bg: #0A0E14;
-                --sidebar-text: #C5CDD8;
-                --sidebar-muted: rgba(197,205,216,0.4);
-                --sidebar-divider: rgba(255,255,255,0.06);
-                --text: #D6DDE8;
-                --text-secondary: #8D97A8;
-                --text-muted: #8490A0;
-                --accent: #5BA3FF;
-                --accent-hover: #7DB8FF;
-                --accent-dim: rgba(91,163,255,0.08);
-                --donate-bg: #C43E1A;
-                --donate-hover: #E55934;
-                --grid-line: rgba(91,163,255,0.04);
-                --grid-dot: rgba(91,163,255,0.08);
-                --section-line: rgba(91,163,255,0.12);
-                --section-dot: var(--accent);
-                --ruler-bg: #1E2530;
-                --ruler-fill: var(--accent);
-                --ruler-mark: rgba(91,163,255,0.2);
-                --card-shadow: 0 1px 4px rgba(0,0,0,0.3);
-                --sidebar-stripe: rgba(255,255,255,0.015);
-                --sidebar-photo-ring: rgba(91,163,255,0.4);
-                --sidebar-link: #7EB8FF;
-                --sidebar-link-hover: #fff;
+                --color-bg: #1A1D24;
+                --color-white: #22262E;
+                --color-text: #D8DEE9;
+                --color-text-dark: #ECEFF4;
+                --color-text-muted: #6B7894;
+                --color-primary: #56C4B4;
+                --color-primary-dark: #7AD4C8;
+                --color-primary-darker: #A0E4DA;
+                --color-skill-bar: #56C4B4;
+                --color-sidebar: #161920;
+                --color-sidebar-overlay: rgba(0, 0, 0, 0.3);
             }
         }
 
@@ -88,153 +61,80 @@
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
         body {
-            font-family: 'Source Sans 3', 'Segoe UI', system-ui, sans-serif;
-            color: var(--text);
-            background: var(--bg);
+            font-family: 'Roboto', system-ui, -apple-system, sans-serif;
+            color: var(--color-text);
+            background: var(--color-bg);
             font-size: 14px;
             line-height: 1.6;
-            padding: 28px;
+            padding: 30px;
             -webkit-font-smoothing: antialiased;
         }
 
-        h1, h2, h3 { font-family: 'Archivo', 'Arial Black', sans-serif; }
-        a { color: var(--accent); text-decoration: none; transition: color 0.2s; }
-        a:hover { color: var(--accent-hover); }
+        h1, h2, h3 { font-family: 'Roboto Slab', 'Georgia', serif; }
+        a { color: var(--color-primary-dark); text-decoration: none; transition: color 0.2s; }
+        a:hover { color: var(--color-primary-darker); }
         ul { list-style: none; }
         img { max-width: 100%; height: auto; }
 
-        /* ===== Grid paper background ===== */
+        /* ===== Layout ===== */
         .cv-wrapper {
             max-width: var(--max-width);
             margin: 0 auto;
             display: grid;
             grid-template-columns: 1fr var(--sidebar-width);
-            box-shadow: var(--card-shadow);
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
             overflow: hidden;
         }
 
-        /* ===== Main Content ===== */
+        /* ===== Main ===== */
         .main-content {
-            background: var(--surface);
-            padding: 52px 52px 52px 56px;
+            background: var(--color-white);
+            padding: 52px 56px;
             order: -1;
-            position: relative;
-            background-image:
-                linear-gradient(var(--grid-line) 1px, transparent 1px),
-                linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
-            background-size: 24px 24px;
         }
 
-        /* ===== Sections ===== */
-        .section {
-            margin-bottom: 48px;
-            page-break-inside: avoid;
-        }
+        .section { margin-bottom: 48px; page-break-inside: avoid; }
         .section:last-child { margin-bottom: 0; }
 
-        /* Section title — annotation style */
         .section-title {
-            font-family: 'Archivo', sans-serif;
-            font-size: 13px;
-            font-weight: 700;
-            letter-spacing: 2.5px;
             text-transform: uppercase;
-            color: var(--accent);
-            margin-bottom: 24px;
-            padding-bottom: 14px;
-            position: relative;
+            font-size: 18px;
+            font-weight: 600;
+            color: var(--color-primary-dark);
+            margin-bottom: 20px;
+            padding-bottom: 10px;
+            border-bottom: 2px solid var(--color-primary);
             display: flex;
             align-items: center;
             gap: 10px;
         }
 
-        /* Dashed line with circle marker */
-        .section-title::after {
-            content: '';
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            border-bottom: 1.5px dashed var(--section-line);
-        }
-
-        .section-title::before {
-            content: '';
-            position: absolute;
-            bottom: -4px;
-            left: 0;
-            width: 8px;
-            height: 8px;
-            border-radius: 50%;
-            background: var(--section-dot);
-            z-index: 1;
-        }
-
         .section-icon {
-            width: 26px;
-            height: 26px;
-            background: var(--accent);
-            border-radius: 4px;
+            width: 30px;
+            height: 30px;
+            background: var(--color-primary);
+            border-radius: 50%;
             display: inline-flex;
             align-items: center;
             justify-content: center;
             flex-shrink: 0;
         }
 
-        .section-icon svg {
-            width: 13px;
-            height: 13px;
-            fill: #fff;
-        }
+        .section-icon svg { width: 14px; height: 14px; fill: #fff; }
 
         /* ===== Summary ===== */
-        .summary {
-            font-size: 14px;
-            line-height: 1.7;
-            color: var(--text-secondary);
-        }
+        .summary { font-size: 14px; line-height: 1.75; color: var(--color-text); }
         .summary p { margin-bottom: 0.9em; }
         .summary p:last-child { margin-bottom: 0; }
-        .summary strong { color: var(--text); font-weight: 600; }
+        .summary strong { color: var(--color-text-dark); font-weight: 700; }
 
         /* ===== Experience ===== */
         .experience-item {
             margin-bottom: 28px;
-            padding-left: 20px;
-            position: relative;
+            padding-left: 16px;
+            border-left: 3px solid var(--color-primary);
         }
         .experience-item:last-child { margin-bottom: 0; }
-
-        /* Vertical timeline line */
-        .experience-item::before {
-            content: '';
-            position: absolute;
-            left: 0;
-            top: 6px;
-            bottom: -28px;
-            width: 1.5px;
-            background: repeating-linear-gradient(
-                to bottom,
-                var(--section-line) 0px,
-                var(--section-line) 4px,
-                transparent 4px,
-                transparent 8px
-            );
-        }
-        .experience-item:last-child::before { bottom: 0; }
-
-        /* Dot on the timeline */
-        .experience-item::after {
-            content: '';
-            position: absolute;
-            left: -3px;
-            top: 6px;
-            width: 8px;
-            height: 8px;
-            border-radius: 50%;
-            background: var(--surface);
-            border: 2px solid var(--accent);
-        }
 
         .experience-header {
             display: flex;
@@ -245,341 +145,169 @@
         }
 
         .job-title {
-            font-family: 'Archivo', sans-serif;
-            color: var(--text);
-            font-size: 15px;
+            color: var(--color-text-dark);
+            font-size: 16px;
             font-weight: 600;
         }
 
         .time {
-            font-family: 'Archivo', sans-serif;
-            font-size: 12px;
-            font-weight: 500;
-            color: var(--text-muted);
+            color: var(--color-text-muted);
             white-space: nowrap;
-            letter-spacing: 0.5px;
+            font-size: 13px;
         }
 
         .company {
+            color: var(--color-primary-dark);
             font-size: 13px;
-            color: var(--accent);
             font-weight: 500;
             margin-bottom: 8px;
         }
 
-        .details { color: var(--text-secondary); font-size: 13px; line-height: 1.65; }
+        .details { color: var(--color-text); font-size: 13px; line-height: 1.65; }
         .details p { margin-bottom: 0.7em; }
         .details p:last-child { margin-bottom: 0; }
-        .details ul { list-style: none; margin-bottom: 0.7em; }
+        .details ul { list-style: disc; margin-left: 18px; margin-bottom: 0.7em; }
         .details ul:last-child { margin-bottom: 0; }
-        .details li {
-            margin-bottom: 4px;
-            padding-left: 16px;
-            position: relative;
-        }
-        .details li::before {
-            content: '';
-            position: absolute;
-            left: 2px;
-            top: 8px;
-            width: 6px;
-            height: 6px;
-            border: 1.5px solid var(--accent);
-            border-radius: 50%;
-        }
+        .details li { margin-bottom: 3px; }
 
-        /* ===== Military toggle ===== */
+        /* ===== Military ===== */
         .military-toggle {
-            font-family: 'Archivo', sans-serif;
-            background: var(--accent-dim);
-            border: 1.5px dashed var(--section-line);
-            color: var(--accent);
+            background: none;
+            border: 1px solid var(--color-primary);
+            color: var(--color-primary-dark);
             font-size: 13px;
-            font-weight: 600;
-            padding: 8px 18px;
+            font-weight: 500;
+            padding: 6px 16px;
             border-radius: 4px;
             cursor: pointer;
             margin-bottom: 28px;
-            transition: background 0.2s, border-color 0.2s;
-            letter-spacing: 0.3px;
+            transition: background 0.2s, color 0.2s;
         }
+        .military-toggle:hover { background: var(--color-primary); color: #fff; }
+        .military-details { display: none; margin-bottom: 28px; }
+        .military-details.open { display: block; }
 
-        .military-toggle:hover {
-            background: var(--accent);
-            border-color: var(--accent);
-            color: #fff;
-        }
-
-        .military-details {
-            display: none;
-            margin-bottom: 28px;
-        }
-
-        .military-details.open {
-            display: block;
-        }
-
-        /* ===== Skills — ruler style ===== */
-        .skill-item {
-            margin-bottom: 16px;
-        }
-
-        .skill-name {
-            font-family: 'Archivo', sans-serif;
-            font-size: 12px;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 1px;
-            color: var(--text);
-            margin-bottom: 8px;
-        }
-
-        .skill-ruler {
+        /* ===== Skills ===== */
+        .skill-item { margin-bottom: 15px; overflow: hidden; }
+        .skill-name { font-size: 14px; font-weight: 500; margin-bottom: 6px; color: var(--color-text-dark); }
+        .skill-bar { height: 10px; background: var(--color-bg); width: 100%; border-radius: 5px; }
+        .skill-bar-inner {
             height: 10px;
-            background: var(--ruler-bg);
-            position: relative;
-            border-radius: 2px;
-            overflow: hidden;
-        }
-
-        /* Ruler tick marks */
-        .skill-ruler::before {
-            content: '';
-            position: absolute;
-            inset: 0;
-            background: repeating-linear-gradient(
-                90deg,
-                transparent 0px,
-                transparent 9px,
-                var(--ruler-mark) 9px,
-                var(--ruler-mark) 10px
-            );
-            z-index: 1;
-        }
-
-        .skill-ruler-fill {
-            height: 100%;
-            background: var(--ruler-fill);
+            background: var(--color-skill-bar);
+            border-radius: 5px;
             width: 0;
-            animation: growBar 0.8s ease-out forwards;
-            position: relative;
-            opacity: 0.7;
+            animation: grow-bar 0.8s ease-out forwards;
         }
+        @keyframes grow-bar { to { width: var(--level); } }
 
-        @keyframes growBar {
-            to { width: var(--level); }
-        }
-
-        /* Tech skills */
         .tech-skills { margin-top: 28px; }
-        .tech-skills h3 {
-            font-family: 'Archivo', sans-serif;
-            font-size: 11px;
-            font-weight: 700;
-            text-transform: uppercase;
-            letter-spacing: 1.5px;
-            color: var(--text-muted);
-            margin-bottom: 8px;
-        }
-        .tech-skills ul {
-            list-style: none;
-            margin-bottom: 14px;
-        }
+        .tech-skills h3 { font-size: 13px; font-weight: 600; color: var(--color-text-dark); margin-bottom: 6px; }
+        .tech-skills ul { list-style: none; margin-bottom: 12px; }
         .tech-skills li {
-            margin-bottom: 4px;
-            padding-left: 16px;
+            margin-bottom: 3px;
+            padding-left: 14px;
             position: relative;
             font-size: 13px;
-            color: var(--text-secondary);
         }
         .tech-skills li::before {
-            content: '';
+            content: "\00B7";
             position: absolute;
             left: 4px;
-            top: 9px;
-            width: 4px;
-            height: 4px;
-            background: var(--accent);
-            border-radius: 1px;
-            transform: rotate(45deg);
+            font-weight: 700;
+            color: var(--color-primary);
         }
 
         /* ===== Sidebar ===== */
         .sidebar {
-            background: var(--sidebar-bg);
-            color: var(--sidebar-text);
-            position: relative;
+            background: var(--color-sidebar);
+            color: #fff;
             min-height: 800px;
         }
 
-        /* Diagonal stripe pattern at top */
-        .sidebar::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            height: 200px;
-            background: repeating-linear-gradient(
-                -45deg,
-                transparent,
-                transparent 8px,
-                var(--sidebar-stripe) 8px,
-                var(--sidebar-stripe) 9px
-            );
-            pointer-events: none;
-        }
+        .sidebar a { color: #fff; text-decoration: none; }
+        .sidebar a:hover { text-decoration: underline; }
 
-        .sidebar a { color: var(--sidebar-link); text-decoration: none; }
-        .sidebar a:hover { color: var(--sidebar-link-hover); text-decoration: underline; }
-
-        /* Profile */
         .profile {
             padding: 36px 28px 28px;
+            background: var(--color-sidebar-overlay);
             text-align: center;
-            position: relative;
-            z-index: 1;
         }
 
         .profile-photo {
-            width: 110px;
-            height: 110px;
+            width: 115px;
+            height: 115px;
             border-radius: 50%;
             margin-bottom: 16px;
-            border: 3px solid var(--sidebar-photo-ring);
-            box-shadow: 0 0 0 6px rgba(45,140,255,0.1);
+            border: 3px solid rgba(255,255,255,0.2);
         }
 
         .profile .name {
-            font-family: 'Archivo', sans-serif;
-            font-size: 22px;
-            font-weight: 800;
-            letter-spacing: -0.3px;
-            margin-bottom: 6px;
-            color: #fff;
+            font-size: 24px;
+            font-weight: 700;
+            margin-bottom: 8px;
         }
 
         .profile .tagline {
-            color: var(--sidebar-muted);
+            color: var(--color-sidebar-muted);
             font-size: 13px;
-            font-weight: 400;
-            letter-spacing: 0.5px;
+            font-weight: 300;
         }
 
-        /* Lang toggle */
         .lang-toggle {
             padding: 10px 28px;
             text-align: center;
-            font-size: 12px;
-            font-weight: 600;
-            letter-spacing: 1px;
-            position: relative;
-            z-index: 1;
+            font-size: 13px;
+            font-weight: 500;
         }
+        .lang-toggle a { opacity: 0.6; }
+        .lang-toggle a:hover { opacity: 1; }
+        .lang-toggle .active { opacity: 1; font-weight: 700; cursor: default; }
 
-        .lang-toggle a { opacity: 0.5; }
-        .lang-toggle a:hover { opacity: 1; text-decoration: none; }
-
-        .lang-toggle .active {
-            opacity: 1;
-            color: #fff;
-            text-decoration: none;
-            cursor: default;
-        }
-
-        /* Donate banner */
-        .donate-banner { padding: 0; position: relative; z-index: 1; }
-
+        .donate-banner { padding: 0; }
         .donate-banner a {
             display: block;
-            background: var(--donate-bg);
+            background: var(--color-donate-bg);
             color: #fff;
-            font-family: 'Archivo', sans-serif;
             font-weight: 700;
             font-size: 13px;
             padding: 14px 28px;
             text-align: center;
             text-decoration: none;
-            letter-spacing: 0.5px;
             transition: background 0.2s;
         }
+        .donate-banner a:hover { background: var(--color-donate-hover); text-decoration: none; }
 
-        .donate-banner a:hover {
-            background: var(--donate-hover);
-            color: #fff;
-            text-decoration: none;
-        }
-
-        /* Sidebar blocks */
-        .sidebar-block {
-            padding: 24px 28px;
-            border-top: 1px solid var(--sidebar-divider);
-            position: relative;
-            z-index: 1;
-        }
-
+        .sidebar-block { padding: 24px 28px; }
         .sidebar-block-title {
-            font-family: 'Archivo', sans-serif;
-            font-size: 10px;
-            font-weight: 700;
             text-transform: uppercase;
-            letter-spacing: 2px;
-            color: var(--sidebar-muted);
+            font-size: 13px;
+            font-weight: 700;
             margin-bottom: 14px;
+            letter-spacing: 0.5px;
         }
 
-        /* Contact */
         .contact-item {
             margin-bottom: 12px;
             display: flex;
             align-items: center;
-            gap: 10px;
+            gap: 8px;
             word-break: break-word;
             font-size: 13px;
         }
         .contact-item:last-child { margin-bottom: 0; }
+        .contact-icon { width: 16px; height: 16px; flex-shrink: 0; fill: rgba(255,255,255,0.7); }
 
-        .contact-icon {
-            width: 16px;
-            height: 16px;
-            flex-shrink: 0;
-            fill: var(--sidebar-muted);
-        }
-
-        /* Education */
         .education-item { margin-bottom: 12px; }
         .education-item:last-child { margin-bottom: 0; }
+        .degree { font-size: 14px; font-weight: 700; margin-bottom: 4px; }
+        .school { color: var(--color-sidebar-muted); font-size: 12px; }
+        .education-dates { color: var(--color-sidebar-muted); font-size: 12px; }
 
-        .degree {
-            font-family: 'Archivo', sans-serif;
-            font-size: 13px;
-            font-weight: 600;
-            margin-bottom: 3px;
-        }
-
-        .school {
-            color: var(--sidebar-muted);
-            font-size: 12px;
-        }
-
-        .education-dates {
-            color: var(--sidebar-muted);
-            font-size: 12px;
-        }
-
-        /* Languages */
-        .lang-item {
-            margin-bottom: 8px;
-            font-size: 13px;
-        }
+        .lang-item { margin-bottom: 8px; font-size: 13px; }
         .lang-item:last-child { margin-bottom: 0; }
-        .lang-level { color: var(--sidebar-muted); font-size: 12px; }
+        .lang-level { color: var(--color-sidebar-muted); }
 
-        /* Interests */
-        .interest-item {
-            margin-bottom: 8px;
-            font-size: 13px;
-        }
+        .interest-item { margin-bottom: 8px; font-size: 13px; }
         .interest-item:last-child { margin-bottom: 0; }
 
         /* ===== Footer ===== */
@@ -589,85 +317,37 @@
             padding: 28px 20px;
             padding-top: 48px;
             text-align: center;
-            color: var(--text-muted);
+            color: var(--color-text-muted);
             font-size: 12px;
             line-height: 1.8;
         }
-
-        .cv-footer a { font-weight: 600; }
+        .cv-footer a { font-weight: 500; color: var(--color-primary-dark); }
 
         /* ===== Responsive ===== */
         @media (max-width: 767px) {
             body { padding: 12px; }
-
-            .cv-wrapper {
-                grid-template-columns: 1fr;
-            }
-
-            .sidebar {
-                min-height: auto;
-                order: -1;
-            }
-
-            .sidebar::before { height: 120px; }
-
-            .main-content {
-                padding: 32px 24px;
-                order: 0;
-            }
-
-            .experience-header {
-                flex-direction: column;
-                gap: 2px;
-            }
-
-            .time {
-                margin-top: 2px;
-            }
+            .cv-wrapper { grid-template-columns: 1fr; }
+            .sidebar { min-height: auto; order: -1; }
+            .main-content { padding: 32px 24px; order: 0; }
+            .experience-header { flex-direction: column; gap: 2px; }
         }
 
         @media (min-width: 992px) {
-            .skill-item {
-                display: flex;
-                align-items: center;
-                gap: 0;
-            }
-
-            .skill-name {
-                width: 28%;
-                flex-shrink: 0;
-                margin-bottom: 0;
-            }
-
-            .skill-ruler {
-                width: 72%;
-            }
+            .skill-item { display: flex; align-items: center; gap: 0; }
+            .skill-name { width: 30%; flex-shrink: 0; margin-bottom: 0; }
+            .skill-bar { width: 70%; }
         }
 
         /* ===== Print ===== */
         @media print {
             body { padding: 0; background: white; font-size: 12px; }
-
-            .cv-wrapper {
-                box-shadow: none;
-                max-width: 100%;
-            }
-
-            .main-content {
-                background-image: none;
-                background: white;
-            }
-
-            .sidebar { background: var(--sidebar-bg) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .sidebar::before { display: none; }
-            .profile-photo { border-color: #999 !important; box-shadow: none !important; }
-            .skill-ruler { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .skill-ruler-fill { -webkit-print-color-adjust: exact; print-color-adjust: exact; animation: none; width: var(--level) !important; }
-
-            .section { margin-bottom: 28px; }
+            .cv-wrapper { box-shadow: none; max-width: 100%; }
+            .main-content { background: white; }
+            .sidebar { background: var(--color-sidebar) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            .skill-bar { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            .skill-bar-inner { -webkit-print-color-adjust: exact; print-color-adjust: exact; animation: none; width: var(--level) !important; }
+            .section { margin-bottom: 24px; }
             .main-content { padding: 28px; }
-            .cv-footer { padding-top: 16px; }
-
             a { text-decoration: none !important; }
             .donate-banner { display: none; }
             .military-toggle { display: none; }
@@ -840,27 +520,27 @@
 
             <div class="skill-item">
                 <h3 class="skill-name">Комунікація</h3>
-                <div class="skill-ruler"><div class="skill-ruler-fill" style="--level: 98%"></div></div>
+                <div class="skill-bar"><div class="skill-bar-inner" style="--level: 98%"></div></div>
             </div>
 
             <div class="skill-item">
                 <h3 class="skill-name">Вирішення проблем</h3>
-                <div class="skill-ruler"><div class="skill-ruler-fill" style="--level: 87%"></div></div>
+                <div class="skill-bar"><div class="skill-bar-inner" style="--level: 87%"></div></div>
             </div>
 
             <div class="skill-item">
                 <h3 class="skill-name">Управління</h3>
-                <div class="skill-ruler"><div class="skill-ruler-fill" style="--level: 97%"></div></div>
+                <div class="skill-bar"><div class="skill-bar-inner" style="--level: 97%"></div></div>
             </div>
 
             <div class="skill-item">
                 <h3 class="skill-name">Аналітика</h3>
-                <div class="skill-ruler"><div class="skill-ruler-fill" style="--level: 95%"></div></div>
+                <div class="skill-bar"><div class="skill-bar-inner" style="--level: 95%"></div></div>
             </div>
 
             <div class="skill-item">
                 <h3 class="skill-name">Технічний</h3>
-                <div class="skill-ruler"><div class="skill-ruler-fill" style="--level: 75%"></div></div>
+                <div class="skill-bar"><div class="skill-bar-inner" style="--level: 75%"></div></div>
             </div>
 
             <div class="tech-skills">

--- a/index.html
+++ b/index.html
@@ -30,12 +30,12 @@
             --sidebar-divider: rgba(255,255,255,0.08);
             --text: #2C3340;
             --text-secondary: #5A6270;
-            --text-muted: #8D95A2;
+            --text-muted: #6B7280;
             --accent: #2D8CFF;
             --accent-hover: #1A6FD4;
             --accent-dim: rgba(45,140,255,0.08);
-            --donate-bg: #E55934;
-            --donate-hover: #C94A2A;
+            --donate-bg: #C43E1A;
+            --donate-hover: #A83415;
             --grid-line: rgba(45,140,255,0.07);
             --grid-dot: rgba(45,140,255,0.12);
             --section-line: rgba(45,140,255,0.18);
@@ -63,12 +63,12 @@
                 --sidebar-divider: rgba(255,255,255,0.06);
                 --text: #D6DDE8;
                 --text-secondary: #8D97A8;
-                --text-muted: #5A6475;
+                --text-muted: #8490A0;
                 --accent: #5BA3FF;
                 --accent-hover: #7DB8FF;
                 --accent-dim: rgba(91,163,255,0.08);
-                --donate-bg: #E55934;
-                --donate-hover: #FF6B42;
+                --donate-bg: #C43E1A;
+                --donate-hover: #E55934;
                 --grid-line: rgba(91,163,255,0.04);
                 --grid-dot: rgba(91,163,255,0.08);
                 --section-line: rgba(91,163,255,0.12);
@@ -706,7 +706,7 @@
             </h2>
 
             <!-- Military service — hidden by default -->
-            <button class="military-toggle" onclick="var d=document.querySelector('.military-details');d.classList.toggle('open');this.textContent=d.classList.contains('open')?'▾ Військова служба':'▸ Військова служба';">▸ Військова служба</button>
+            <button class="military-toggle" aria-expanded="false" onclick="var d=document.querySelector('.military-details');d.classList.toggle('open');var o=d.classList.contains('open');this.textContent=o?'▾ Військова служба':'▸ Військова служба';this.setAttribute('aria-expanded',o);">▸ Військова служба</button>
 
             <div class="military-details">
                 <div class="experience-item">

--- a/manager-en.html
+++ b/manager-en.html
@@ -7,7 +7,6 @@
     <meta name="description" content="CV Iurii Klekovkin | Manager | Team Leader | Process Transformation | Project Management | Process Optimization | Stakeholder Management | Cross-functional Coordination">
     <meta name="author" content="Iurii Klekovkin">
 
-    <!-- Open Graph -->
     <meta property="og:title" content="Iurii Klekovkin — Manager CV">
     <meta property="og:description" content="Manager · Team Leader · Process Transformation">
     <meta property="og:type" content="profile">
@@ -17,27 +16,44 @@
     <link rel="icon" type="image/png" href="favicon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700;900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700;900&family=Roboto+Slab:wght@400;500;600;700&display=swap" rel="stylesheet">
 
     <style>
-        /* ======= Custom Properties ======= */
         :root {
-            --color-primary: #42A8C0;
-            --color-primary-dark: #2d7788;
-            --color-primary-darker: #1a454f;
-            --color-text: #545E6C;
-            --color-text-dark: #3F4650;
-            --color-text-muted: #97AAC3;
-            --color-bg: #f5f5f5;
-            --color-white: #fff;
-            --color-skill-bar: #7bc2d3;
-            --color-sidebar-overlay: rgba(0, 0, 0, 0.2);
-            --color-sidebar-muted: rgba(255, 255, 255, 0.6);
-            --sidebar-width: 240px;
-            --max-width: 960px;
+            --color-primary: #2A9D8F;
+            --color-primary-dark: #1E7A6E;
+            --color-primary-darker: #145650;
+            --color-text: #3B4252;
+            --color-text-dark: #2E3440;
+            --color-text-muted: #8B95A5;
+            --color-bg: #F5F5F5;
+            --color-white: #FFFFFF;
+            --color-skill-bar: #6EC6B8;
+            --color-sidebar: #264653;
+            --color-sidebar-overlay: rgba(0, 0, 0, 0.15);
+            --color-sidebar-muted: rgba(255, 255, 255, 0.55);
+            --color-donate-bg: #E76F51;
+            --color-donate-hover: #D45A3C;
+            --sidebar-width: 250px;
+            --max-width: 980px;
         }
 
-        /* ======= Reset & Base ======= */
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --color-bg: #1A1D24;
+                --color-white: #22262E;
+                --color-text: #D8DEE9;
+                --color-text-dark: #ECEFF4;
+                --color-text-muted: #6B7894;
+                --color-primary: #56C4B4;
+                --color-primary-dark: #7AD4C8;
+                --color-primary-darker: #A0E4DA;
+                --color-skill-bar: #56C4B4;
+                --color-sidebar: #161920;
+                --color-sidebar-overlay: rgba(0, 0, 0, 0.3);
+            }
+        }
+
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
         body {
@@ -45,43 +61,43 @@
             color: var(--color-text);
             background: var(--color-bg);
             font-size: 14px;
-            line-height: 1.5;
+            line-height: 1.6;
             padding: 30px;
             -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
         }
 
-        h1, h2, h3, h4, h5, h6 { font-weight: 700; }
-        a { color: var(--color-primary-dark); transition: color 0.3s; }
+        h1, h2, h3 { font-family: 'Roboto Slab', 'Georgia', serif; }
+        a { color: var(--color-primary-dark); text-decoration: none; transition: color 0.2s; }
         a:hover { color: var(--color-primary-darker); }
         ul { list-style: none; }
         img { max-width: 100%; height: auto; }
 
-        /* ======= Layout ======= */
         .cv-wrapper {
             max-width: var(--max-width);
             margin: 0 auto;
             display: grid;
             grid-template-columns: 1fr var(--sidebar-width);
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+            overflow: hidden;
         }
 
-        /* ======= Main Content ======= */
         .main-content {
             background: var(--color-white);
-            padding: 60px;
+            padding: 52px 56px;
             order: -1;
         }
 
-        .section { margin-bottom: 60px; page-break-inside: avoid; }
+        .section { margin-bottom: 48px; page-break-inside: avoid; }
         .section:last-child { margin-bottom: 0; }
 
         .section-title {
             text-transform: uppercase;
-            font-size: 20px;
-            font-weight: 500;
+            font-size: 18px;
+            font-weight: 600;
             color: var(--color-primary-dark);
             margin-bottom: 20px;
+            padding-bottom: 10px;
+            border-bottom: 2px solid var(--color-primary);
             display: flex;
             align-items: center;
             gap: 10px;
@@ -90,7 +106,7 @@
         .section-icon {
             width: 30px;
             height: 30px;
-            background: var(--color-primary-dark);
+            background: var(--color-primary);
             border-radius: 50%;
             display: inline-flex;
             align-items: center;
@@ -98,18 +114,18 @@
             flex-shrink: 0;
         }
 
-        .section-icon svg {
-            width: 14px;
-            height: 14px;
-            fill: var(--color-white);
-        }
+        .section-icon svg { width: 14px; height: 14px; fill: #fff; }
 
-        /* ======= Summary ======= */
-        .summary p { margin-bottom: 1em; }
+        .summary { font-size: 14px; line-height: 1.75; color: var(--color-text); }
+        .summary p { margin-bottom: 0.9em; }
         .summary p:last-child { margin-bottom: 0; }
+        .summary strong { color: var(--color-text-dark); font-weight: 700; }
 
-        /* ======= Experience ======= */
-        .experience-item { margin-bottom: 30px; }
+        .experience-item {
+            margin-bottom: 28px;
+            padding-left: 16px;
+            border-left: 3px solid var(--color-primary);
+        }
         .experience-item:last-child { margin-bottom: 0; }
 
         .experience-header {
@@ -117,283 +133,191 @@
             justify-content: space-between;
             align-items: baseline;
             margin-bottom: 2px;
+            gap: 12px;
         }
 
         .job-title {
             color: var(--color-text-dark);
             font-size: 16px;
-            font-weight: 500;
+            font-weight: 600;
         }
 
         .time {
             color: var(--color-text-muted);
             white-space: nowrap;
-            margin-left: 10px;
+            font-size: 13px;
         }
 
         .company {
-            color: var(--color-text-muted);
-            margin-bottom: 10px;
+            color: var(--color-primary-dark);
+            font-size: 13px;
+            font-weight: 500;
+            margin-bottom: 8px;
         }
 
-        .details p { margin-bottom: 0.8em; }
+        .details { color: var(--color-text); font-size: 13px; line-height: 1.65; }
+        .details p { margin-bottom: 0.7em; }
         .details p:last-child { margin-bottom: 0; }
-        .details ul { list-style: disc; margin-left: 20px; margin-bottom: 0.8em; }
+        .details ul { list-style: disc; margin-left: 18px; margin-bottom: 0.7em; }
         .details ul:last-child { margin-bottom: 0; }
-        .details li { margin-bottom: 0.3em; }
+        .details li { margin-bottom: 3px; }
 
-        /* ======= Skills ======= */
-        .skill-item {
-            margin-bottom: 15px;
-            overflow: hidden;
-        }
-
-        .skill-name {
-            font-size: 14px;
-            font-weight: 700;
-            margin-bottom: 12px;
-        }
-
-        .skill-bar {
-            height: 12px;
-            background: var(--color-bg);
-            width: 100%;
-        }
-
+        .skill-item { margin-bottom: 15px; overflow: hidden; }
+        .skill-name { font-size: 14px; font-weight: 500; margin-bottom: 6px; color: var(--color-text-dark); }
+        .skill-bar { height: 10px; background: var(--color-bg); width: 100%; border-radius: 5px; }
         .skill-bar-inner {
-            height: 12px;
+            height: 10px;
             background: var(--color-skill-bar);
+            border-radius: 5px;
             width: 0;
-            animation: grow-bar 1s ease-out forwards;
+            animation: grow-bar 0.8s ease-out forwards;
+        }
+        @keyframes grow-bar { to { width: var(--level); } }
+
+        .tech-skills { margin-top: 28px; }
+        .tech-skills h3 { font-size: 13px; font-weight: 600; color: var(--color-text-dark); margin-bottom: 6px; }
+        .tech-skills ul { list-style: none; margin-bottom: 12px; }
+        .tech-skills li {
+            margin-bottom: 3px;
+            padding-left: 14px;
+            position: relative;
+            font-size: 13px;
+        }
+        .tech-skills li::before {
+            content: "\00b7";
+            position: absolute;
+            left: 4px;
+            font-weight: 700;
+            color: var(--color-primary);
         }
 
-        @keyframes grow-bar {
-            to { width: var(--level); }
-        }
-
-        /* ======= Sidebar ======= */
         .sidebar {
-            background: var(--color-primary);
-            color: var(--color-white);
+            background: var(--color-sidebar);
+            color: #fff;
             min-height: 800px;
         }
 
-        .sidebar a { color: var(--color-white); text-decoration: none; }
-        .sidebar a:hover { text-decoration: underline; color: var(--color-white); }
+        .sidebar a { color: #fff; text-decoration: none; }
+        .sidebar a:hover { text-decoration: underline; }
 
-        /* Profile */
         .profile {
-            padding: 30px;
+            padding: 36px 28px 28px;
             background: var(--color-sidebar-overlay);
             text-align: center;
         }
 
         .profile-photo {
-            width: 120px;
-            height: 120px;
+            width: 115px;
+            height: 115px;
             border-radius: 50%;
-            margin-bottom: 15px;
+            margin-bottom: 16px;
+            border: 3px solid rgba(255,255,255,0.2);
         }
 
         .profile .name {
-            font-size: 32px;
-            font-weight: 900;
-            margin-bottom: 10px;
+            font-size: 24px;
+            font-weight: 700;
+            margin-bottom: 8px;
         }
 
         .profile .tagline {
             color: var(--color-sidebar-muted);
-            font-size: 16px;
-            font-weight: 400;
+            font-size: 13px;
+            font-weight: 300;
         }
 
-        /* Sidebar blocks */
-        .sidebar-block {
-            padding: 30px;
-        }
-
-        .sidebar-block-title {
-            text-transform: uppercase;
-            font-size: 16px;
-            font-weight: 700;
-            margin-bottom: 15px;
-        }
-
-        /* Language toggle */
         .lang-toggle {
-            padding: 10px 30px;
+            padding: 10px 28px;
             text-align: center;
             font-size: 13px;
             font-weight: 500;
         }
+        .lang-toggle a { opacity: 0.6; }
+        .lang-toggle a:hover { opacity: 1; }
+        .lang-toggle .active { opacity: 1; font-weight: 700; cursor: default; }
 
-        .lang-toggle a {
-            opacity: 0.7;
-        }
-
-        .lang-toggle a:hover {
-            opacity: 1;
-        }
-
-        .lang-toggle .active {
-            opacity: 1;
+        .donate-banner { padding: 0; }
+        .donate-banner a {
+            display: block;
+            background: var(--color-donate-bg);
+            color: #fff;
             font-weight: 700;
+            font-size: 13px;
+            padding: 14px 28px;
+            text-align: center;
             text-decoration: none;
-            cursor: default;
+            transition: background 0.2s;
+        }
+        .donate-banner a:hover { background: var(--color-donate-hover); text-decoration: none; }
+
+        .sidebar-block { padding: 24px 28px; }
+        .sidebar-block-title {
+            text-transform: uppercase;
+            font-size: 13px;
+            font-weight: 700;
+            margin-bottom: 14px;
+            letter-spacing: 0.5px;
         }
 
-        /* Contact */
         .contact-item {
-            margin-bottom: 15px;
+            margin-bottom: 12px;
             display: flex;
             align-items: center;
             gap: 8px;
             word-break: break-word;
+            font-size: 13px;
         }
-
         .contact-item:last-child { margin-bottom: 0; }
+        .contact-icon { width: 16px; height: 16px; flex-shrink: 0; fill: rgba(255,255,255,0.7); }
 
-        .contact-icon {
-            width: 18px;
-            height: 18px;
-            flex-shrink: 0;
-            fill: var(--color-white);
-        }
-
-        /* Education */
-        .education-item { margin-bottom: 15px; }
+        .education-item { margin-bottom: 12px; }
         .education-item:last-child { margin-bottom: 0; }
+        .degree { font-size: 14px; font-weight: 700; margin-bottom: 4px; }
+        .school { color: var(--color-sidebar-muted); font-size: 12px; }
+        .education-dates { color: var(--color-sidebar-muted); font-size: 12px; }
 
-        .degree {
-            font-size: 14px;
-            font-weight: 700;
-            margin-bottom: 5px;
-        }
-
-        .school {
-            color: var(--color-sidebar-muted);
-            font-weight: 500;
-            font-size: 13px;
-        }
-
-        .education-dates {
-            color: var(--color-sidebar-muted);
-            font-weight: 500;
-            font-size: 13px;
-        }
-
-        /* Languages */
-        .lang-item { margin-bottom: 10px; }
+        .lang-item { margin-bottom: 8px; font-size: 13px; }
         .lang-item:last-child { margin-bottom: 0; }
         .lang-level { color: var(--color-sidebar-muted); }
 
-        /* Interests */
-        .interest-item { margin-bottom: 10px; }
+        .interest-item { margin-bottom: 8px; font-size: 13px; }
         .interest-item:last-child { margin-bottom: 0; }
 
-        /* ======= Donate Banner ======= */
-        .donate-banner {
-            padding: 0;
-        }
-
-        .donate-banner a {
-            display: block;
-            background: #FBB03B;
-            color: #000080;
-            font-weight: 700;
-            text-decoration: none;
-            font-size: 14px;
-            padding: 14px 30px;
-            text-align: center;
-            transition: background 0.3s;
-        }
-
-        .donate-banner a:hover {
-            background: #e09a2a;
-            text-decoration: none;
-            color: #000080;
-        }
-
-        /* ======= Footer ======= */
         .cv-footer {
             max-width: var(--max-width);
             margin: 0 auto;
-            padding: 30px;
-            padding-top: 60px;
+            padding: 28px 20px;
+            padding-top: 48px;
             text-align: center;
-            color: var(--color-text);
-            font-size: 13px;
-            line-height: 1.6;
+            color: var(--color-text-muted);
+            font-size: 12px;
+            line-height: 1.8;
         }
+        .cv-footer a { font-weight: 500; color: var(--color-primary-dark); }
 
-        .cv-footer a {
-            font-weight: 500;
-        }
-
-        /* ======= Responsive ======= */
         @media (max-width: 767px) {
-            body { padding: 15px; }
-
-            .cv-wrapper {
-                grid-template-columns: 1fr;
-            }
-
-            .sidebar {
-                min-height: auto;
-                order: -1;
-            }
-
-            .main-content {
-                padding: 30px;
-                order: 0;
-            }
-
-            .experience-header {
-                flex-direction: column;
-            }
-
-            .time {
-                margin-left: 0;
-                margin-top: 4px;
-            }
+            body { padding: 12px; }
+            .cv-wrapper { grid-template-columns: 1fr; }
+            .sidebar { min-height: auto; order: -1; }
+            .main-content { padding: 32px 24px; order: 0; }
+            .experience-header { flex-direction: column; gap: 2px; }
         }
 
         @media (min-width: 992px) {
-            .skill-item {
-                display: flex;
-                align-items: center;
-                gap: 0;
-            }
-
-            .skill-name {
-                width: 30%;
-                flex-shrink: 0;
-                margin-bottom: 0;
-            }
-
-            .skill-bar {
-                width: 70%;
-            }
+            .skill-item { display: flex; align-items: center; gap: 0; }
+            .skill-name { width: 30%; flex-shrink: 0; margin-bottom: 0; }
+            .skill-bar { width: 70%; }
         }
 
-        /* ======= Print ======= */
         @media print {
             body { padding: 0; background: white; font-size: 12px; }
-
-            .cv-wrapper {
-                box-shadow: none;
-                max-width: 100%;
-            }
-
-            .sidebar { background: var(--color-primary) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .profile { background: var(--color-sidebar-overlay) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .skill-bar { background: var(--color-bg) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .skill-bar-inner { background: var(--color-skill-bar) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; animation: none; width: var(--level) !important; }
-
-            .section { margin-bottom: 30px; }
-            .main-content { padding: 30px; }
-            .cv-footer { padding-top: 20px; }
-
+            .cv-wrapper { box-shadow: none; max-width: 100%; }
+            .main-content { background: white; }
+            .sidebar { background: var(--color-sidebar) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            .skill-bar { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            .skill-bar-inner { -webkit-print-color-adjust: exact; print-color-adjust: exact; animation: none; width: var(--level) !important; }
+            .section { margin-bottom: 24px; }
+            .main-content { padding: 28px; }
             a { text-decoration: none !important; }
             .donate-banner { display: none; }
         }
@@ -404,12 +328,9 @@
 <div class="cv-wrapper">
     <main class="main-content">
 
-        <!-- Career Profile -->
         <section class="section">
             <h2 class="section-title">
-                <span class="section-icon">
-                    <svg viewBox="0 0 448 512"><path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512H418.3c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304H178.3z"/></svg>
-                </span>
+                <span class="section-icon"><svg viewBox="0 0 448 512"><path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512H418.3c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304H178.3z"/></svg></span>
                 Who am I
             </h2>
             <div class="summary">
@@ -420,16 +341,11 @@
             </div>
         </section>
 
-        <!-- Experience -->
         <section class="section">
             <h2 class="section-title">
-                <span class="section-icon">
-                    <svg viewBox="0 0 512 512"><path d="M184 48H328c4.4 0 8 3.6 8 8V96H176V56c0-4.4 3.6-8 8-8zm-56 8V96H64C28.7 96 0 124.7 0 160v96H192 320 512V160c0-35.3-28.7-64-64-64H384V56c0-30.9-25.1-56-56-56H184c-30.9 0-56 25.1-56 56zM512 288H320v32c0 17.7-14.3 32-32 32H224c-17.7 0-32-14.3-32-32V288H0V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V288z"/></svg>
-                </span>
+                <span class="section-icon"><svg viewBox="0 0 512 512"><path d="M184 48H328c4.4 0 8 3.6 8 8V96H176V56c0-4.4 3.6-8 8-8zm-56 8V96H64C28.7 96 0 124.7 0 160v96H192 320 512V160c0-35.3-28.7-64-64-64H384V56c0-30.9-25.1-56-56-56H184c-30.9 0-56 25.1-56 56zM512 288H320v32c0 17.7-14.3 32-32 32H224c-17.7 0-32-14.3-32-32V288H0V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V288z"/></svg></span>
                 Experience
             </h2>
-
-            <!-- NO military service on English pages -->
 
             <div class="experience-item">
                 <div class="experience-header">
@@ -437,14 +353,12 @@
                     <span class="time">May 2021 - April 2025</span>
                 </div>
                 <div class="company">Ledger</div>
-                <div class="details">
-                    <ul>
-                        <li>Coordinated cross-functional collaboration between development, security, and operations teams for a cryptocurrency SaaS platform</li>
-                        <li>Managed continuous delivery processes and deployment workflows serving millions of users</li>
-                        <li>Implemented practices and standards for production infrastructure reliability</li>
-                        <li>Optimized CI/CD processes, reducing incidents and accelerating delivery cycles</li>
-                    </ul>
-                </div>
+                <div class="details"><ul>
+                    <li>Coordinated cross-functional collaboration between development, security, and operations teams for a cryptocurrency SaaS platform</li>
+                    <li>Managed continuous delivery processes and deployment workflows serving millions of users</li>
+                    <li>Implemented practices and standards for production infrastructure reliability</li>
+                    <li>Optimized CI/CD processes, reducing incidents and accelerating delivery cycles</li>
+                </ul></div>
             </div>
 
             <div class="experience-item">
@@ -453,13 +367,11 @@
                     <span class="time">August 2019 - May 2021</span>
                 </div>
                 <div class="company">Ledger</div>
-                <div class="details">
-                    <ul>
-                        <li>Collaborated with development teams to establish DevOps workflows and deployment standards</li>
-                        <li>Managed infrastructure processes ensuring environment consistency</li>
-                        <li>Coordinated provisioning automation to improve team efficiency</li>
-                    </ul>
-                </div>
+                <div class="details"><ul>
+                    <li>Collaborated with development teams to establish DevOps workflows and deployment standards</li>
+                    <li>Managed infrastructure processes ensuring environment consistency</li>
+                    <li>Coordinated provisioning automation to improve team efficiency</li>
+                </ul></div>
             </div>
 
             <div class="experience-item">
@@ -468,13 +380,11 @@
                     <span class="time">November 2022 - August 2025</span>
                 </div>
                 <div class="company">Astroquirks</div>
-                <div class="details">
-                    <ul>
-                        <li>Co-founded blockchain validation project, responsible for the full cycle — from design to operations</li>
-                        <li>Designed and delivered full technical stack with 99.9% uptime</li>
-                        <li>Implemented monitoring and auto-recovery processes</li>
-                    </ul>
-                </div>
+                <div class="details"><ul>
+                    <li>Co-founded blockchain validation project, responsible for the full cycle — from design to operations</li>
+                    <li>Designed and delivered full technical stack with 99.9% uptime</li>
+                    <li>Implemented monitoring and auto-recovery processes</li>
+                </ul></div>
             </div>
 
             <div class="experience-item">
@@ -483,20 +393,18 @@
                     <span class="time">October 2013 - October 2018</span>
                 </div>
                 <div class="company">PortaOne, Kyiv</div>
-                <div class="details">
-                    <ul>
-                        <li>Led technical support team providing L3/L4 level service for VoIP billing systems</li>
-                        <li>Created and implemented new cross-departmental interaction processes</li>
-                        <li>Participated in company culture development and building employer brand in Ukraine</li>
-                        <li>Established processes and standards for collaboration between Development, QA, and Product Management</li>
-                        <li>Optimized support process, created and integrated new motivational system</li>
-                        <li>Built a highly skilled support group and team</li>
-                        <li>Reduced employee turnover</li>
-                        <li>Implemented weekly 1:1 meetings across all departments</li>
-                        <li>Implemented continuous personal growth system in Ukrainian branches</li>
-                        <li>Managed complex software deployments and system integrations for global enterprise clients</li>
-                    </ul>
-                </div>
+                <div class="details"><ul>
+                    <li>Led technical support team providing L3/L4 level service for VoIP billing systems</li>
+                    <li>Created and implemented new cross-departmental interaction processes</li>
+                    <li>Participated in company culture development and building employer brand in Ukraine</li>
+                    <li>Established processes and standards for collaboration between Development, QA, and Product Management</li>
+                    <li>Optimized support process, created and integrated new motivational system</li>
+                    <li>Built a highly skilled support group and team</li>
+                    <li>Reduced employee turnover</li>
+                    <li>Implemented weekly 1:1 meetings across all departments</li>
+                    <li>Implemented continuous personal growth system in Ukrainian branches</li>
+                    <li>Managed complex software deployments and system integrations for global enterprise clients</li>
+                </ul></div>
             </div>
 
             <div class="experience-item">
@@ -505,14 +413,12 @@
                     <span class="time">October 2008 - October 2013</span>
                 </div>
                 <div class="company">PortaOne, Kyiv</div>
-                <div class="details">
-                    <ul>
-                        <li>Dispatching and control of support group daily tasks</li>
-                        <li>Creation of various documentation</li>
-                        <li>On-site technical consulting for clients worldwide</li>
-                        <li>Executed complex maintenance scenarios and migrations with minimal downtime</li>
-                    </ul>
-                </div>
+                <div class="details"><ul>
+                    <li>Dispatching and control of support group daily tasks</li>
+                    <li>Creation of various documentation</li>
+                    <li>On-site technical consulting for clients worldwide</li>
+                    <li>Executed complex maintenance scenarios and migrations with minimal downtime</li>
+                </ul></div>
             </div>
 
             <div class="experience-item">
@@ -538,12 +444,9 @@
             </div>
         </section>
 
-        <!-- Skills -->
         <section class="section">
             <h2 class="section-title">
-                <span class="section-icon">
-                    <svg viewBox="0 0 512 512"><path d="M156.6 384.9L125.7 354c-8.5-8.5-11.5-20.8-7.7-32.2c3-8.9 7.7-17.4 13.9-25.2L48.5 213c-11.3-11.3-11.3-29.6 0-40.8l57.4-56.7c11.3-11.3 29.5-11.3 40.8 0l83.5 83.5c7.8-6.1 16.3-10.8 25.2-13.7c11.4-3.9 23.7-.8 32.2 7.7l30.9 30.9c5.7 5.7 8.7 13.5 8.4 21.6c19.4 14.6 34.5 34.4 43.5 57.5H480c17.7 0 32-14.3 32-32V64c0-17.7-14.3-32-32-32H64C46.3 32 32 46.3 32 64V352c0 17.7 14.3 32 32 32h92.5zM256 224a64 64 0 1 1 0 128 64 64 0 1 1 0-128zm-43.3 203.3l-20.6-20.6-76.2 76.2c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l76.2-76.2-20.6-20.6c-1.3-1.3-2.5-2.7-3.6-4.1zM393.4 307.2l-39.6-39.6c-3.3 5.7-7.2 11-11.7 15.5s-9.9 8.4-15.5 11.7l39.6 39.6 27.1-27.1z"/></svg>
-                </span>
+                <span class="section-icon"><svg viewBox="0 0 512 512"><path d="M156.6 384.9L125.7 354c-8.5-8.5-11.5-20.8-7.7-32.2c3-8.9 7.7-17.4 13.9-25.2L48.5 213c-11.3-11.3-11.3-29.6 0-40.8l57.4-56.7c11.3-11.3 29.5-11.3 40.8 0l83.5 83.5c7.8-6.1 16.3-10.8 25.2-13.7c11.4-3.9 23.7-.8 32.2 7.7l30.9 30.9c5.7 5.7 8.7 13.5 8.4 21.6c19.4 14.6 34.5 34.4 43.5 57.5H480c17.7 0 32-14.3 32-32V64c0-17.7-14.3-32-32-32H64C46.3 32 32 46.3 32 64V352c0 17.7 14.3 32 32 32h92.5zM256 224a64 64 0 1 1 0 128 64 64 0 1 1 0-128zm-43.3 203.3l-20.6-20.6-76.2 76.2c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l76.2-76.2-20.6-20.6c-1.3-1.3-2.5-2.7-3.6-4.1zM393.4 307.2l-39.6-39.6c-3.3 5.7-7.2 11-11.7 15.5s-9.9 8.4-15.5 11.7l39.6 39.6 27.1-27.1z"/></svg></span>
                 Skills &amp; Proficiency
             </h2>
 
@@ -577,50 +480,29 @@
                 <div class="skill-bar"><div class="skill-bar-inner" style="--level: 63%"></div></div>
             </div>
 
-            <p style="margin-top: 20px; color: var(--color-text-muted); font-size: 13px;"><strong>Tech stack:</strong> Kubernetes, AWS, Terraform, Helm, ArgoCD, Prometheus, Grafana, Linux, CI/CD</p>
+            <div class="tech-skills">
+                <h3>Tech stack</h3>
+                <ul><li>Kubernetes, AWS, Terraform, Helm, ArgoCD, Prometheus, Grafana, Linux, CI/CD</li></ul>
+            </div>
         </section>
 
     </main>
 
     <aside class="sidebar">
-        <!-- Profile -->
         <div class="profile">
             <img class="profile-photo" src="profile.png" alt="Iurii Klekovkin" width="120" height="120">
             <h1 class="name">Iurii Klekovkin</h1>
             <p class="tagline">Manager · Team Leader · Process Transformation</p>
         </div>
-
-        <!-- Language toggle -->
-        <div class="lang-toggle">
-            <a href="manager-ua.html">UA</a> | <span class="active">EN</span>
-        </div>
-
-        <!-- Donate Banner -->
-        <div class="donate-banner">
-            <a href="donate.html">Support UAF / Підтримати ЗСУ</a>
-        </div>
-
-        <!-- Contact -->
+        <div class="lang-toggle"><a href="manager-ua.html">UA</a> | <span class="active">EN</span></div>
+        <div class="donate-banner"><a href="donate.html">Support UAF / Підтримати ЗСУ</a></div>
         <div class="sidebar-block">
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 512 512"><path d="M48 64C21.5 64 0 85.5 0 112c0 15.1 7.1 29.3 19.2 38.4L236.8 313.6c11.4 8.5 27 8.5 38.4 0L492.8 150.4c12.1-9.1 19.2-23.3 19.2-38.4c0-26.5-21.5-48-48-48H48zM0 176V384c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V176L294.4 339.2c-22.8 17.1-54 17.1-76.8 0L0 176z"/></svg>
-                <a href="mailto:iurii@klekovkin.com.ua">iurii@klekovkin.com.ua</a>
-            </div>
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 512 512"><path d="M164.9 24.6c-7.7-18.6-28-28.5-47.4-23.2l-88 24C12.1 30.2 0 46 0 64C0 311.4 200.6 512 448 512c18 0 33.8-12.1 38.6-29.5l24-88c5.3-19.4-4.6-39.7-23.2-47.4l-96-40c-16.3-6.8-35.2-2.1-46.3 11.6L304.7 368C234.3 334.7 177.3 277.7 144 207.3L193.3 167c13.7-11.2 18.4-30 11.6-46.3l-40-96z"/></svg>
-                <a href="tel:+380937791847">+380 93 779 1847</a>
-            </div>
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 448 512"><path d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg>
-                <a href="https://www.linkedin.com/in/klekovkin">in/klekovkin</a>
-            </div>
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 496 512"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.8-14.9-112.8-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/></svg>
-                <a href="https://github.com/depomytymoped">depomytymoped</a>
-            </div>
+            <h2 class="sidebar-block-title">Contact</h2>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 512 512"><path d="M48 64C21.5 64 0 85.5 0 112c0 15.1 7.1 29.3 19.2 38.4L236.8 313.6c11.4 8.5 27 8.5 38.4 0L492.8 150.4c12.1-9.1 19.2-23.3 19.2-38.4c0-26.5-21.5-48-48-48H48zM0 176V384c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V176L294.4 339.2c-22.8 17.1-54 17.1-76.8 0L0 176z"/></svg><a href="mailto:iurii@klekovkin.com.ua">iurii@klekovkin.com.ua</a></div>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 512 512"><path d="M164.9 24.6c-7.7-18.6-28-28.5-47.4-23.2l-88 24C12.1 30.2 0 46 0 64C0 311.4 200.6 512 448 512c18 0 33.8-12.1 38.6-29.5l24-88c5.3-19.4-4.6-39.7-23.2-47.4l-96-40c-16.3-6.8-35.2-2.1-46.3 11.6L304.7 368C234.3 334.7 177.3 277.7 144 207.3L193.3 167c13.7-11.2 18.4-30 11.6-46.3l-40-96z"/></svg><a href="tel:+380937791847">+380 93 779 1847</a></div>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 448 512"><path d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg><a href="https://www.linkedin.com/in/klekovkin">in/klekovkin</a></div>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 496 512"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.8-14.9-112.8-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/></svg><a href="https://github.com/depomytymoped">depomytymoped</a></div>
         </div>
-
-        <!-- Education -->
         <div class="sidebar-block">
             <h2 class="sidebar-block-title">Education</h2>
             <div class="education-item">
@@ -629,16 +511,12 @@
                 <div class="education-dates">2001 - 2019</div>
             </div>
         </div>
-
-        <!-- Languages -->
         <div class="sidebar-block">
             <h2 class="sidebar-block-title">Languages</h2>
             <div class="lang-item">Ukrainian <span class="lang-level">(Native)</span></div>
             <div class="lang-item">English <span class="lang-level">(Professional)</span></div>
             <div class="lang-item">Russian <span class="lang-level">(Beginner)</span></div>
         </div>
-
-        <!-- Interests -->
         <div class="sidebar-block">
             <h2 class="sidebar-block-title">Interests</h2>
             <div class="interest-item">Continuous growth</div>

--- a/manager-ua.html
+++ b/manager-ua.html
@@ -7,7 +7,6 @@
     <meta name="description" content="CV Юрій Клековкін | Менеджер | Лідер команд | Трансформація процесів | Управління проєктами | Оптимізація процесів | Стейкхолдер менеджмент | Крос-функціональна координація">
     <meta name="author" content="Iurii Klekovkin">
 
-    <!-- Open Graph -->
     <meta property="og:title" content="Юрій Клековкін — Manager CV">
     <meta property="og:description" content="Менеджер · Лідер команд · Трансформація процесів">
     <meta property="og:type" content="profile">
@@ -17,27 +16,44 @@
     <link rel="icon" type="image/png" href="favicon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700;900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700;900&family=Roboto+Slab:wght@400;500;600;700&display=swap" rel="stylesheet">
 
     <style>
-        /* ======= Custom Properties ======= */
         :root {
-            --color-primary: #42A8C0;
-            --color-primary-dark: #2d7788;
-            --color-primary-darker: #1a454f;
-            --color-text: #545E6C;
-            --color-text-dark: #3F4650;
-            --color-text-muted: #97AAC3;
-            --color-bg: #f5f5f5;
-            --color-white: #fff;
-            --color-skill-bar: #7bc2d3;
-            --color-sidebar-overlay: rgba(0, 0, 0, 0.2);
-            --color-sidebar-muted: rgba(255, 255, 255, 0.6);
-            --sidebar-width: 240px;
-            --max-width: 960px;
+            --color-primary: #2A9D8F;
+            --color-primary-dark: #1E7A6E;
+            --color-primary-darker: #145650;
+            --color-text: #3B4252;
+            --color-text-dark: #2E3440;
+            --color-text-muted: #8B95A5;
+            --color-bg: #F5F5F5;
+            --color-white: #FFFFFF;
+            --color-skill-bar: #6EC6B8;
+            --color-sidebar: #264653;
+            --color-sidebar-overlay: rgba(0, 0, 0, 0.15);
+            --color-sidebar-muted: rgba(255, 255, 255, 0.55);
+            --color-donate-bg: #E76F51;
+            --color-donate-hover: #D45A3C;
+            --sidebar-width: 250px;
+            --max-width: 980px;
         }
 
-        /* ======= Reset & Base ======= */
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --color-bg: #1A1D24;
+                --color-white: #22262E;
+                --color-text: #D8DEE9;
+                --color-text-dark: #ECEFF4;
+                --color-text-muted: #6B7894;
+                --color-primary: #56C4B4;
+                --color-primary-dark: #7AD4C8;
+                --color-primary-darker: #A0E4DA;
+                --color-skill-bar: #56C4B4;
+                --color-sidebar: #161920;
+                --color-sidebar-overlay: rgba(0, 0, 0, 0.3);
+            }
+        }
+
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
         body {
@@ -45,43 +61,43 @@
             color: var(--color-text);
             background: var(--color-bg);
             font-size: 14px;
-            line-height: 1.5;
+            line-height: 1.6;
             padding: 30px;
             -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
         }
 
-        h1, h2, h3, h4, h5, h6 { font-weight: 700; }
-        a { color: var(--color-primary-dark); transition: color 0.3s; }
+        h1, h2, h3 { font-family: 'Roboto Slab', 'Georgia', serif; }
+        a { color: var(--color-primary-dark); text-decoration: none; transition: color 0.2s; }
         a:hover { color: var(--color-primary-darker); }
         ul { list-style: none; }
         img { max-width: 100%; height: auto; }
 
-        /* ======= Layout ======= */
         .cv-wrapper {
             max-width: var(--max-width);
             margin: 0 auto;
             display: grid;
             grid-template-columns: 1fr var(--sidebar-width);
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+            overflow: hidden;
         }
 
-        /* ======= Main Content ======= */
         .main-content {
             background: var(--color-white);
-            padding: 60px;
+            padding: 52px 56px;
             order: -1;
         }
 
-        .section { margin-bottom: 60px; page-break-inside: avoid; }
+        .section { margin-bottom: 48px; page-break-inside: avoid; }
         .section:last-child { margin-bottom: 0; }
 
         .section-title {
             text-transform: uppercase;
-            font-size: 20px;
-            font-weight: 500;
+            font-size: 18px;
+            font-weight: 600;
             color: var(--color-primary-dark);
             margin-bottom: 20px;
+            padding-bottom: 10px;
+            border-bottom: 2px solid var(--color-primary);
             display: flex;
             align-items: center;
             gap: 10px;
@@ -90,7 +106,7 @@
         .section-icon {
             width: 30px;
             height: 30px;
-            background: var(--color-primary-dark);
+            background: var(--color-primary);
             border-radius: 50%;
             display: inline-flex;
             align-items: center;
@@ -98,18 +114,18 @@
             flex-shrink: 0;
         }
 
-        .section-icon svg {
-            width: 14px;
-            height: 14px;
-            fill: var(--color-white);
-        }
+        .section-icon svg { width: 14px; height: 14px; fill: #fff; }
 
-        /* ======= Summary ======= */
-        .summary p { margin-bottom: 1em; }
+        .summary { font-size: 14px; line-height: 1.75; color: var(--color-text); }
+        .summary p { margin-bottom: 0.9em; }
         .summary p:last-child { margin-bottom: 0; }
+        .summary strong { color: var(--color-text-dark); font-weight: 700; }
 
-        /* ======= Experience ======= */
-        .experience-item { margin-bottom: 30px; }
+        .experience-item {
+            margin-bottom: 28px;
+            padding-left: 16px;
+            border-left: 3px solid var(--color-primary);
+        }
         .experience-item:last-child { margin-bottom: 0; }
 
         .experience-header {
@@ -117,312 +133,207 @@
             justify-content: space-between;
             align-items: baseline;
             margin-bottom: 2px;
+            gap: 12px;
         }
 
         .job-title {
             color: var(--color-text-dark);
             font-size: 16px;
-            font-weight: 500;
+            font-weight: 600;
         }
 
         .time {
             color: var(--color-text-muted);
             white-space: nowrap;
-            margin-left: 10px;
+            font-size: 13px;
         }
 
         .company {
-            color: var(--color-text-muted);
-            margin-bottom: 10px;
+            color: var(--color-primary-dark);
+            font-size: 13px;
+            font-weight: 500;
+            margin-bottom: 8px;
         }
 
-        .details p { margin-bottom: 0.8em; }
+        .details { color: var(--color-text); font-size: 13px; line-height: 1.65; }
+        .details p { margin-bottom: 0.7em; }
         .details p:last-child { margin-bottom: 0; }
-        .details ul { list-style: disc; margin-left: 20px; margin-bottom: 0.8em; }
+        .details ul { list-style: disc; margin-left: 18px; margin-bottom: 0.7em; }
         .details ul:last-child { margin-bottom: 0; }
-        .details li { margin-bottom: 0.3em; }
+        .details li { margin-bottom: 3px; }
 
-        /* ======= Military Service (collapsible) ======= */
         .military-toggle {
             background: none;
             border: 1px solid var(--color-primary);
             color: var(--color-primary-dark);
-            font-family: inherit;
-            font-size: 14px;
+            font-size: 13px;
             font-weight: 500;
-            padding: 8px 16px;
+            padding: 6px 16px;
             border-radius: 4px;
             cursor: pointer;
-            margin-bottom: 30px;
+            margin-bottom: 28px;
             transition: background 0.2s, color 0.2s;
         }
+        .military-toggle:hover { background: var(--color-primary); color: #fff; }
+        .military-details { display: none; margin-bottom: 28px; }
+        .military-details.open { display: block; }
 
-        .military-toggle:hover {
-            background: var(--color-primary);
-            color: var(--color-white);
-        }
-
-        .military-details {
-            display: none;
-            margin-bottom: 30px;
-        }
-
-        .military-details.open {
-            display: block;
-        }
-
-        /* ======= Skills ======= */
-        .skill-item {
-            margin-bottom: 15px;
-            overflow: hidden;
-        }
-
-        .skill-name {
-            font-size: 14px;
-            font-weight: 700;
-            margin-bottom: 12px;
-        }
-
-        .skill-bar {
-            height: 12px;
-            background: var(--color-bg);
-            width: 100%;
-        }
-
+        .skill-item { margin-bottom: 15px; overflow: hidden; }
+        .skill-name { font-size: 14px; font-weight: 500; margin-bottom: 6px; color: var(--color-text-dark); }
+        .skill-bar { height: 10px; background: var(--color-bg); width: 100%; border-radius: 5px; }
         .skill-bar-inner {
-            height: 12px;
+            height: 10px;
             background: var(--color-skill-bar);
+            border-radius: 5px;
             width: 0;
-            animation: grow-bar 1s ease-out forwards;
+            animation: grow-bar 0.8s ease-out forwards;
+        }
+        @keyframes grow-bar { to { width: var(--level); } }
+
+        .tech-skills { margin-top: 28px; }
+        .tech-skills h3 { font-size: 13px; font-weight: 600; color: var(--color-text-dark); margin-bottom: 6px; }
+        .tech-skills ul { list-style: none; margin-bottom: 12px; }
+        .tech-skills li {
+            margin-bottom: 3px;
+            padding-left: 14px;
+            position: relative;
+            font-size: 13px;
+        }
+        .tech-skills li::before {
+            content: "\00b7";
+            position: absolute;
+            left: 4px;
+            font-weight: 700;
+            color: var(--color-primary);
         }
 
-        @keyframes grow-bar {
-            to { width: var(--level); }
-        }
-
-        /* ======= Sidebar ======= */
         .sidebar {
-            background: var(--color-primary);
-            color: var(--color-white);
+            background: var(--color-sidebar);
+            color: #fff;
             min-height: 800px;
         }
 
-        .sidebar a { color: var(--color-white); text-decoration: none; }
-        .sidebar a:hover { text-decoration: underline; color: var(--color-white); }
+        .sidebar a { color: #fff; text-decoration: none; }
+        .sidebar a:hover { text-decoration: underline; }
 
-        /* Profile */
         .profile {
-            padding: 30px;
+            padding: 36px 28px 28px;
             background: var(--color-sidebar-overlay);
             text-align: center;
         }
 
         .profile-photo {
-            width: 120px;
-            height: 120px;
+            width: 115px;
+            height: 115px;
             border-radius: 50%;
-            margin-bottom: 15px;
+            margin-bottom: 16px;
+            border: 3px solid rgba(255,255,255,0.2);
         }
 
         .profile .name {
-            font-size: 32px;
-            font-weight: 900;
-            margin-bottom: 10px;
+            font-size: 24px;
+            font-weight: 700;
+            margin-bottom: 8px;
         }
 
         .profile .tagline {
             color: var(--color-sidebar-muted);
-            font-size: 16px;
-            font-weight: 400;
+            font-size: 13px;
+            font-weight: 300;
         }
 
-        /* Sidebar blocks */
-        .sidebar-block {
-            padding: 30px;
-        }
-
-        .sidebar-block-title {
-            text-transform: uppercase;
-            font-size: 16px;
-            font-weight: 700;
-            margin-bottom: 15px;
-        }
-
-        /* Language toggle */
         .lang-toggle {
-            padding: 10px 30px;
+            padding: 10px 28px;
             text-align: center;
             font-size: 13px;
             font-weight: 500;
         }
+        .lang-toggle a { opacity: 0.6; }
+        .lang-toggle a:hover { opacity: 1; }
+        .lang-toggle .active { opacity: 1; font-weight: 700; cursor: default; }
 
-        .lang-toggle a {
-            opacity: 0.7;
-        }
-
-        .lang-toggle a:hover {
-            opacity: 1;
-        }
-
-        .lang-toggle .active {
-            opacity: 1;
+        .donate-banner { padding: 0; }
+        .donate-banner a {
+            display: block;
+            background: var(--color-donate-bg);
+            color: #fff;
             font-weight: 700;
+            font-size: 13px;
+            padding: 14px 28px;
+            text-align: center;
             text-decoration: none;
-            cursor: default;
+            transition: background 0.2s;
+        }
+        .donate-banner a:hover { background: var(--color-donate-hover); text-decoration: none; }
+
+        .sidebar-block { padding: 24px 28px; }
+        .sidebar-block-title {
+            text-transform: uppercase;
+            font-size: 13px;
+            font-weight: 700;
+            margin-bottom: 14px;
+            letter-spacing: 0.5px;
         }
 
-        /* Contact */
         .contact-item {
-            margin-bottom: 15px;
+            margin-bottom: 12px;
             display: flex;
             align-items: center;
             gap: 8px;
             word-break: break-word;
+            font-size: 13px;
         }
-
         .contact-item:last-child { margin-bottom: 0; }
+        .contact-icon { width: 16px; height: 16px; flex-shrink: 0; fill: rgba(255,255,255,0.7); }
 
-        .contact-icon {
-            width: 18px;
-            height: 18px;
-            flex-shrink: 0;
-            fill: var(--color-white);
-        }
-
-        /* Education */
-        .education-item { margin-bottom: 15px; }
+        .education-item { margin-bottom: 12px; }
         .education-item:last-child { margin-bottom: 0; }
+        .degree { font-size: 14px; font-weight: 700; margin-bottom: 4px; }
+        .school { color: var(--color-sidebar-muted); font-size: 12px; }
+        .education-dates { color: var(--color-sidebar-muted); font-size: 12px; }
 
-        .degree {
-            font-size: 14px;
-            font-weight: 700;
-            margin-bottom: 5px;
-        }
-
-        .school {
-            color: var(--color-sidebar-muted);
-            font-weight: 500;
-            font-size: 13px;
-        }
-
-        .education-dates {
-            color: var(--color-sidebar-muted);
-            font-weight: 500;
-            font-size: 13px;
-        }
-
-        /* Languages */
-        .lang-item { margin-bottom: 10px; }
+        .lang-item { margin-bottom: 8px; font-size: 13px; }
         .lang-item:last-child { margin-bottom: 0; }
         .lang-level { color: var(--color-sidebar-muted); }
 
-        /* Interests */
-        .interest-item { margin-bottom: 10px; }
+        .interest-item { margin-bottom: 8px; font-size: 13px; }
         .interest-item:last-child { margin-bottom: 0; }
 
-        /* ======= Donate Banner ======= */
-        .donate-banner {
-            padding: 0;
-        }
-
-        .donate-banner a {
-            display: block;
-            background: #FBB03B;
-            color: #000080;
-            font-weight: 700;
-            text-decoration: none;
-            font-size: 14px;
-            padding: 14px 30px;
-            text-align: center;
-            transition: background 0.3s;
-        }
-
-        .donate-banner a:hover {
-            background: #e09a2a;
-            text-decoration: none;
-            color: #000080;
-        }
-
-        /* ======= Footer ======= */
         .cv-footer {
             max-width: var(--max-width);
             margin: 0 auto;
-            padding: 30px;
-            padding-top: 60px;
+            padding: 28px 20px;
+            padding-top: 48px;
             text-align: center;
-            color: var(--color-text);
-            font-size: 13px;
-            line-height: 1.6;
+            color: var(--color-text-muted);
+            font-size: 12px;
+            line-height: 1.8;
         }
+        .cv-footer a { font-weight: 500; color: var(--color-primary-dark); }
 
-        .cv-footer a {
-            font-weight: 500;
-        }
-
-        /* ======= Responsive ======= */
         @media (max-width: 767px) {
-            body { padding: 15px; }
-
-            .cv-wrapper {
-                grid-template-columns: 1fr;
-            }
-
-            .sidebar {
-                min-height: auto;
-                order: -1;
-            }
-
-            .main-content {
-                padding: 30px;
-                order: 0;
-            }
-
-            .experience-header {
-                flex-direction: column;
-            }
-
-            .time {
-                margin-left: 0;
-                margin-top: 4px;
-            }
+            body { padding: 12px; }
+            .cv-wrapper { grid-template-columns: 1fr; }
+            .sidebar { min-height: auto; order: -1; }
+            .main-content { padding: 32px 24px; order: 0; }
+            .experience-header { flex-direction: column; gap: 2px; }
         }
 
         @media (min-width: 992px) {
-            .skill-item {
-                display: flex;
-                align-items: center;
-                gap: 0;
-            }
-
-            .skill-name {
-                width: 30%;
-                flex-shrink: 0;
-                margin-bottom: 0;
-            }
-
-            .skill-bar {
-                width: 70%;
-            }
+            .skill-item { display: flex; align-items: center; gap: 0; }
+            .skill-name { width: 30%; flex-shrink: 0; margin-bottom: 0; }
+            .skill-bar { width: 70%; }
         }
 
-        /* ======= Print ======= */
         @media print {
             body { padding: 0; background: white; font-size: 12px; }
-
-            .cv-wrapper {
-                box-shadow: none;
-                max-width: 100%;
-            }
-
-            .sidebar { background: var(--color-primary) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .profile { background: var(--color-sidebar-overlay) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .skill-bar { background: var(--color-bg) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .skill-bar-inner { background: var(--color-skill-bar) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; animation: none; width: var(--level) !important; }
-
-            .section { margin-bottom: 30px; }
-            .main-content { padding: 30px; }
-            .cv-footer { padding-top: 20px; }
-
+            .cv-wrapper { box-shadow: none; max-width: 100%; }
+            .main-content { background: white; }
+            .sidebar { background: var(--color-sidebar) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            .skill-bar { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            .skill-bar-inner { -webkit-print-color-adjust: exact; print-color-adjust: exact; animation: none; width: var(--level) !important; }
+            .section { margin-bottom: 24px; }
+            .main-content { padding: 28px; }
             a { text-decoration: none !important; }
             .donate-banner { display: none; }
             .military-toggle { display: none; }
@@ -435,12 +346,9 @@
 <div class="cv-wrapper">
     <main class="main-content">
 
-        <!-- Професійний профіль -->
         <section class="section">
             <h2 class="section-title">
-                <span class="section-icon">
-                    <svg viewBox="0 0 448 512"><path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512H418.3c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304H178.3z"/></svg>
-                </span>
+                <span class="section-icon"><svg viewBox="0 0 448 512"><path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512H418.3c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304H178.3z"/></svg></span>
                 Хто я
             </h2>
             <div class="summary">
@@ -451,17 +359,13 @@
             </div>
         </section>
 
-        <!-- Досвід -->
         <section class="section">
             <h2 class="section-title">
-                <span class="section-icon">
-                    <svg viewBox="0 0 512 512"><path d="M184 48H328c4.4 0 8 3.6 8 8V96H176V56c0-4.4 3.6-8 8-8zm-56 8V96H64C28.7 96 0 124.7 0 160v96H192 320 512V160c0-35.3-28.7-64-64-64H384V56c0-30.9-25.1-56-56-56H184c-30.9 0-56 25.1-56 56zM512 288H320v32c0 17.7-14.3 32-32 32H224c-17.7 0-32-14.3-32-32V288H0V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V288z"/></svg>
-                </span>
+                <span class="section-icon"><svg viewBox="0 0 512 512"><path d="M184 48H328c4.4 0 8 3.6 8 8V96H176V56c0-4.4 3.6-8 8-8zm-56 8V96H64C28.7 96 0 124.7 0 160v96H192 320 512V160c0-35.3-28.7-64-64-64H384V56c0-30.9-25.1-56-56-56H184c-30.9 0-56 25.1-56 56zM512 288H320v32c0 17.7-14.3 32-32 32H224c-17.7 0-32-14.3-32-32V288H0V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V288z"/></svg></span>
                 Досвід
             </h2>
 
-            <!-- Military service — hidden by default -->
-            <button class="military-toggle" onclick="var d=document.querySelector('.military-details');d.classList.toggle('open');this.textContent=d.classList.contains('open')?'▾ Військова служба':'▸ Військова служба';">▸ Військова служба</button>
+            <button class="military-toggle" aria-expanded="false" onclick="var d=document.querySelector('.military-details');d.classList.toggle('open');var o=d.classList.contains('open');this.textContent=o?'▾ Військова служба':'▸ Військова служба';this.setAttribute('aria-expanded',o);">▸ Військова служба</button>
 
             <div class="military-details">
                 <div class="experience-item">
@@ -588,12 +492,9 @@
             </div>
         </section>
 
-        <!-- Навички -->
         <section class="section">
             <h2 class="section-title">
-                <span class="section-icon">
-                    <svg viewBox="0 0 512 512"><path d="M156.6 384.9L125.7 354c-8.5-8.5-11.5-20.8-7.7-32.2c3-8.9 7.7-17.4 13.9-25.2L48.5 213c-11.3-11.3-11.3-29.6 0-40.8l57.4-56.7c11.3-11.3 29.5-11.3 40.8 0l83.5 83.5c7.8-6.1 16.3-10.8 25.2-13.7c11.4-3.9 23.7-.8 32.2 7.7l30.9 30.9c5.7 5.7 8.7 13.5 8.4 21.6c19.4 14.6 34.5 34.4 43.5 57.5H480c17.7 0 32-14.3 32-32V64c0-17.7-14.3-32-32-32H64C46.3 32 32 46.3 32 64V352c0 17.7 14.3 32 32 32h92.5zM256 224a64 64 0 1 1 0 128 64 64 0 1 1 0-128zm-43.3 203.3l-20.6-20.6-76.2 76.2c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l76.2-76.2-20.6-20.6c-1.3-1.3-2.5-2.7-3.6-4.1zM393.4 307.2l-39.6-39.6c-3.3 5.7-7.2 11-11.7 15.5s-9.9 8.4-15.5 11.7l39.6 39.6 27.1-27.1z"/></svg>
-                </span>
+                <span class="section-icon"><svg viewBox="0 0 512 512"><path d="M156.6 384.9L125.7 354c-8.5-8.5-11.5-20.8-7.7-32.2c3-8.9 7.7-17.4 13.9-25.2L48.5 213c-11.3-11.3-11.3-29.6 0-40.8l57.4-56.7c11.3-11.3 29.5-11.3 40.8 0l83.5 83.5c7.8-6.1 16.3-10.8 25.2-13.7c11.4-3.9 23.7-.8 32.2 7.7l30.9 30.9c5.7 5.7 8.7 13.5 8.4 21.6c19.4 14.6 34.5 34.4 43.5 57.5H480c17.7 0 32-14.3 32-32V64c0-17.7-14.3-32-32-32H64C46.3 32 32 46.3 32 64V352c0 17.7 14.3 32 32 32h92.5zM256 224a64 64 0 1 1 0 128 64 64 0 1 1 0-128zm-43.3 203.3l-20.6-20.6-76.2 76.2c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l76.2-76.2-20.6-20.6c-1.3-1.3-2.5-2.7-3.6-4.1zM393.4 307.2l-39.6-39.6c-3.3 5.7-7.2 11-11.7 15.5s-9.9 8.4-15.5 11.7l39.6 39.6 27.1-27.1z"/></svg></span>
                 Навички
             </h2>
 
@@ -627,50 +528,31 @@
                 <div class="skill-bar"><div class="skill-bar-inner" style="--level: 63%"></div></div>
             </div>
 
-            <p style="margin-top: 20px; color: var(--color-text-muted); font-size: 13px;"><strong>Технічний стек:</strong> Kubernetes, AWS, Terraform, Helm, ArgoCD, Prometheus, Grafana, Linux, CI/CD</p>
+            <div class="tech-skills">
+                <h3>Технічний стек</h3>
+                <ul>
+                    <li>Kubernetes, AWS, Terraform, Helm, ArgoCD, Prometheus, Grafana, Linux, CI/CD</li>
+                </ul>
+            </div>
         </section>
 
     </main>
 
     <aside class="sidebar">
-        <!-- Profile -->
         <div class="profile">
-            <img class="profile-photo" src="profile.png" alt="Юрій Клековкін" width="120" height="120">
+            <img class="profile-photo" src="profile.png" alt="Юрій Клековкін" width="115" height="115">
             <h1 class="name">Юрій Клековкін</h1>
             <p class="tagline">Менеджер · Лідер команд · Трансформація процесів</p>
         </div>
-
-        <!-- Language toggle -->
-        <div class="lang-toggle">
-            <span class="active">UA</span> | <a href="manager-en.html">EN</a>
-        </div>
-
-        <!-- Donate Banner -->
-        <div class="donate-banner">
-            <a href="donate.html">Підтримати ЗСУ / Support UAF</a>
-        </div>
-
-        <!-- Контакти -->
+        <div class="lang-toggle"><span class="active">UA</span> | <a href="manager-en.html">EN</a></div>
+        <div class="donate-banner"><a href="donate.html">Підтримати ЗСУ / Support UAF</a></div>
         <div class="sidebar-block">
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 512 512"><path d="M48 64C21.5 64 0 85.5 0 112c0 15.1 7.1 29.3 19.2 38.4L236.8 313.6c11.4 8.5 27 8.5 38.4 0L492.8 150.4c12.1-9.1 19.2-23.3 19.2-38.4c0-26.5-21.5-48-48-48H48zM0 176V384c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V176L294.4 339.2c-22.8 17.1-54 17.1-76.8 0L0 176z"/></svg>
-                <a href="mailto:iurii@klekovkin.com.ua">iurii@klekovkin.com.ua</a>
-            </div>
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 512 512"><path d="M164.9 24.6c-7.7-18.6-28-28.5-47.4-23.2l-88 24C12.1 30.2 0 46 0 64C0 311.4 200.6 512 448 512c18 0 33.8-12.1 38.6-29.5l24-88c5.3-19.4-4.6-39.7-23.2-47.4l-96-40c-16.3-6.8-35.2-2.1-46.3 11.6L304.7 368C234.3 334.7 177.3 277.7 144 207.3L193.3 167c13.7-11.2 18.4-30 11.6-46.3l-40-96z"/></svg>
-                <a href="tel:+380937791847">+380 93 779 1847</a>
-            </div>
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 448 512"><path d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg>
-                <a href="https://www.linkedin.com/in/klekovkin">in/klekovkin</a>
-            </div>
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 496 512"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.8-14.9-112.8-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/></svg>
-                <a href="https://github.com/depomytymoped">depomytymoped</a>
-            </div>
+            <h2 class="sidebar-block-title">Контакти</h2>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 512 512"><path d="M48 64C21.5 64 0 85.5 0 112c0 15.1 7.1 29.3 19.2 38.4L236.8 313.6c11.4 8.5 27 8.5 38.4 0L492.8 150.4c12.1-9.1 19.2-23.3 19.2-38.4c0-26.5-21.5-48-48-48H48zM0 176V384c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V176L294.4 339.2c-22.8 17.1-54 17.1-76.8 0L0 176z"/></svg><a href="mailto:iurii@klekovkin.com.ua">iurii@klekovkin.com.ua</a></div>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 512 512"><path d="M164.9 24.6c-7.7-18.6-28-28.5-47.4-23.2l-88 24C12.1 30.2 0 46 0 64C0 311.4 200.6 512 448 512c18 0 33.8-12.1 38.6-29.5l24-88c5.3-19.4-4.6-39.7-23.2-47.4l-96-40c-16.3-6.8-35.2-2.1-46.3 11.6L304.7 368C234.3 334.7 177.3 277.7 144 207.3L193.3 167c13.7-11.2 18.4-30 11.6-46.3l-40-96z"/></svg><a href="tel:+380937791847">+380 93 779 1847</a></div>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 448 512"><path d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg><a href="https://www.linkedin.com/in/klekovkin">in/klekovkin</a></div>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 496 512"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.8-14.9-112.8-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/></svg><a href="https://github.com/depomytymoped">depomytymoped</a></div>
         </div>
-
-        <!-- Освіта -->
         <div class="sidebar-block">
             <h2 class="sidebar-block-title">Освіта</h2>
             <div class="education-item">
@@ -679,16 +561,12 @@
                 <div class="education-dates">2001 - 2019</div>
             </div>
         </div>
-
-        <!-- Мови -->
         <div class="sidebar-block">
             <h2 class="sidebar-block-title">Мови</h2>
             <div class="lang-item">Українська <span class="lang-level">(Рідна)</span></div>
             <div class="lang-item">Англійська <span class="lang-level">(Професійний)</span></div>
             <div class="lang-item">Російська <span class="lang-level">(Початковий)</span></div>
         </div>
-
-        <!-- Інтереси -->
         <div class="sidebar-block">
             <h2 class="sidebar-block-title">Інтереси</h2>
             <div class="interest-item">Безперервний розвиток</div>

--- a/sre-en.html
+++ b/sre-en.html
@@ -7,7 +7,6 @@
     <meta name="description" content="CV Iurii Klekovkin | Site Reliability Engineer | DevOps Engineer | Kubernetes, Terraform, AWS, EKS, CI/CD, ArgoCD, Prometheus, Grafana | Infrastructure as Code | Monitoring & Observability">
     <meta name="author" content="Iurii Klekovkin">
 
-    <!-- Open Graph -->
     <meta property="og:title" content="Iurii Klekovkin — SRE / DevOps CV">
     <meta property="og:description" content="Site Reliability Engineer · DevOps Engineer">
     <meta property="og:type" content="profile">
@@ -17,27 +16,44 @@
     <link rel="icon" type="image/png" href="favicon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700;900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700;900&family=Roboto+Slab:wght@400;500;600;700&display=swap" rel="stylesheet">
 
     <style>
-        /* ======= Custom Properties ======= */
         :root {
-            --color-primary: #42A8C0;
-            --color-primary-dark: #2d7788;
-            --color-primary-darker: #1a454f;
-            --color-text: #545E6C;
-            --color-text-dark: #3F4650;
-            --color-text-muted: #97AAC3;
-            --color-bg: #f5f5f5;
-            --color-white: #fff;
-            --color-skill-bar: #7bc2d3;
-            --color-sidebar-overlay: rgba(0, 0, 0, 0.2);
-            --color-sidebar-muted: rgba(255, 255, 255, 0.6);
-            --sidebar-width: 240px;
-            --max-width: 960px;
+            --color-primary: #2A9D8F;
+            --color-primary-dark: #1E7A6E;
+            --color-primary-darker: #145650;
+            --color-text: #3B4252;
+            --color-text-dark: #2E3440;
+            --color-text-muted: #8B95A5;
+            --color-bg: #F5F5F5;
+            --color-white: #FFFFFF;
+            --color-skill-bar: #6EC6B8;
+            --color-sidebar: #264653;
+            --color-sidebar-overlay: rgba(0, 0, 0, 0.15);
+            --color-sidebar-muted: rgba(255, 255, 255, 0.55);
+            --color-donate-bg: #E76F51;
+            --color-donate-hover: #D45A3C;
+            --sidebar-width: 250px;
+            --max-width: 980px;
         }
 
-        /* ======= Reset & Base ======= */
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --color-bg: #1A1D24;
+                --color-white: #22262E;
+                --color-text: #D8DEE9;
+                --color-text-dark: #ECEFF4;
+                --color-text-muted: #6B7894;
+                --color-primary: #56C4B4;
+                --color-primary-dark: #7AD4C8;
+                --color-primary-darker: #A0E4DA;
+                --color-skill-bar: #56C4B4;
+                --color-sidebar: #161920;
+                --color-sidebar-overlay: rgba(0, 0, 0, 0.3);
+            }
+        }
+
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
         body {
@@ -45,43 +61,43 @@
             color: var(--color-text);
             background: var(--color-bg);
             font-size: 14px;
-            line-height: 1.5;
+            line-height: 1.6;
             padding: 30px;
             -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
         }
 
-        h1, h2, h3, h4, h5, h6 { font-weight: 700; }
-        a { color: var(--color-primary-dark); transition: color 0.3s; }
+        h1, h2, h3 { font-family: 'Roboto Slab', 'Georgia', serif; }
+        a { color: var(--color-primary-dark); text-decoration: none; transition: color 0.2s; }
         a:hover { color: var(--color-primary-darker); }
         ul { list-style: none; }
         img { max-width: 100%; height: auto; }
 
-        /* ======= Layout ======= */
         .cv-wrapper {
             max-width: var(--max-width);
             margin: 0 auto;
             display: grid;
             grid-template-columns: 1fr var(--sidebar-width);
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+            overflow: hidden;
         }
 
-        /* ======= Main Content ======= */
         .main-content {
             background: var(--color-white);
-            padding: 60px;
+            padding: 52px 56px;
             order: -1;
         }
 
-        .section { margin-bottom: 60px; page-break-inside: avoid; }
+        .section { margin-bottom: 48px; page-break-inside: avoid; }
         .section:last-child { margin-bottom: 0; }
 
         .section-title {
             text-transform: uppercase;
-            font-size: 20px;
-            font-weight: 500;
+            font-size: 18px;
+            font-weight: 600;
             color: var(--color-primary-dark);
             margin-bottom: 20px;
+            padding-bottom: 10px;
+            border-bottom: 2px solid var(--color-primary);
             display: flex;
             align-items: center;
             gap: 10px;
@@ -90,7 +106,7 @@
         .section-icon {
             width: 30px;
             height: 30px;
-            background: var(--color-primary-dark);
+            background: var(--color-primary);
             border-radius: 50%;
             display: inline-flex;
             align-items: center;
@@ -98,18 +114,18 @@
             flex-shrink: 0;
         }
 
-        .section-icon svg {
-            width: 14px;
-            height: 14px;
-            fill: var(--color-white);
-        }
+        .section-icon svg { width: 14px; height: 14px; fill: #fff; }
 
-        /* ======= Summary ======= */
-        .summary p { margin-bottom: 1em; }
+        .summary { font-size: 14px; line-height: 1.75; color: var(--color-text); }
+        .summary p { margin-bottom: 0.9em; }
         .summary p:last-child { margin-bottom: 0; }
+        .summary strong { color: var(--color-text-dark); font-weight: 700; }
 
-        /* ======= Experience ======= */
-        .experience-item { margin-bottom: 30px; }
+        .experience-item {
+            margin-bottom: 28px;
+            padding-left: 16px;
+            border-left: 3px solid var(--color-primary);
+        }
         .experience-item:last-child { margin-bottom: 0; }
 
         .experience-header {
@@ -117,258 +133,171 @@
             justify-content: space-between;
             align-items: baseline;
             margin-bottom: 2px;
+            gap: 12px;
         }
 
         .job-title {
             color: var(--color-text-dark);
             font-size: 16px;
-            font-weight: 500;
+            font-weight: 600;
         }
 
         .time {
             color: var(--color-text-muted);
             white-space: nowrap;
-            margin-left: 10px;
+            font-size: 13px;
         }
 
         .company {
-            color: var(--color-text-muted);
-            margin-bottom: 10px;
-        }
-
-        .details p { margin-bottom: 0.8em; }
-        .details p:last-child { margin-bottom: 0; }
-        .details ul { list-style: disc; margin-left: 20px; margin-bottom: 0.8em; }
-        .details ul:last-child { margin-bottom: 0; }
-        .details li { margin-bottom: 0.3em; }
-
-        /* ======= Skills ======= */
-        /* Technical skills list */
-        .tech-skills { margin-top: 30px; }
-        .tech-skills h3 {
-            font-size: 14px;
-            font-weight: 700;
-            color: var(--color-text-dark);
+            color: var(--color-primary-dark);
+            font-size: 13px;
+            font-weight: 500;
             margin-bottom: 8px;
         }
-        .tech-skills ul {
-            list-style: none;
-            margin-bottom: 12px;
-        }
+
+        .details { color: var(--color-text); font-size: 13px; line-height: 1.65; }
+        .details p { margin-bottom: 0.7em; }
+        .details p:last-child { margin-bottom: 0; }
+        .details ul { list-style: disc; margin-left: 18px; margin-bottom: 0.7em; }
+        .details ul:last-child { margin-bottom: 0; }
+        .details li { margin-bottom: 3px; }
+
+        .tech-skills { margin-top: 28px; }
+        .tech-skills h3 { font-size: 13px; font-weight: 600; color: var(--color-text-dark); margin-bottom: 6px; }
+        .tech-skills ul { list-style: none; margin-bottom: 12px; }
         .tech-skills li {
-            margin-bottom: 4px;
-            padding-left: 16px;
+            margin-bottom: 3px;
+            padding-left: 14px;
             position: relative;
+            font-size: 13px;
         }
         .tech-skills li::before {
-            content: "·";
+            content: "\00b7";
             position: absolute;
             left: 4px;
             font-weight: 700;
+            color: var(--color-primary);
         }
 
-        /* ======= Sidebar ======= */
         .sidebar {
-            background: var(--color-primary);
-            color: var(--color-white);
+            background: var(--color-sidebar);
+            color: #fff;
             min-height: 800px;
         }
 
-        .sidebar a { color: var(--color-white); text-decoration: none; }
-        .sidebar a:hover { text-decoration: underline; color: var(--color-white); }
+        .sidebar a { color: #fff; text-decoration: none; }
+        .sidebar a:hover { text-decoration: underline; }
 
-        /* Profile */
         .profile {
-            padding: 30px;
+            padding: 36px 28px 28px;
             background: var(--color-sidebar-overlay);
             text-align: center;
         }
 
         .profile-photo {
-            width: 120px;
-            height: 120px;
+            width: 115px;
+            height: 115px;
             border-radius: 50%;
-            margin-bottom: 15px;
+            margin-bottom: 16px;
+            border: 3px solid rgba(255,255,255,0.2);
         }
 
         .profile .name {
-            font-size: 32px;
-            font-weight: 900;
-            margin-bottom: 10px;
+            font-size: 24px;
+            font-weight: 700;
+            margin-bottom: 8px;
         }
 
         .profile .tagline {
             color: var(--color-sidebar-muted);
-            font-size: 16px;
-            font-weight: 400;
+            font-size: 13px;
+            font-weight: 300;
         }
 
-        /* Sidebar blocks */
-        .sidebar-block {
-            padding: 30px;
-        }
-
-        .sidebar-block-title {
-            text-transform: uppercase;
-            font-size: 16px;
-            font-weight: 700;
-            margin-bottom: 15px;
-        }
-
-        /* Language toggle */
         .lang-toggle {
-            padding: 10px 30px;
+            padding: 10px 28px;
             text-align: center;
             font-size: 13px;
             font-weight: 500;
         }
+        .lang-toggle a { opacity: 0.6; }
+        .lang-toggle a:hover { opacity: 1; }
+        .lang-toggle .active { opacity: 1; font-weight: 700; cursor: default; }
 
-        .lang-toggle a {
-            opacity: 0.7;
-        }
-
-        .lang-toggle a:hover {
-            opacity: 1;
-        }
-
-        .lang-toggle .active {
-            opacity: 1;
+        .donate-banner { padding: 0; }
+        .donate-banner a {
+            display: block;
+            background: var(--color-donate-bg);
+            color: #fff;
             font-weight: 700;
+            font-size: 13px;
+            padding: 14px 28px;
+            text-align: center;
             text-decoration: none;
-            cursor: default;
+            transition: background 0.2s;
+        }
+        .donate-banner a:hover { background: var(--color-donate-hover); text-decoration: none; }
+
+        .sidebar-block { padding: 24px 28px; }
+        .sidebar-block-title {
+            text-transform: uppercase;
+            font-size: 13px;
+            font-weight: 700;
+            margin-bottom: 14px;
+            letter-spacing: 0.5px;
         }
 
-        /* Contact */
         .contact-item {
-            margin-bottom: 15px;
+            margin-bottom: 12px;
             display: flex;
             align-items: center;
             gap: 8px;
             word-break: break-word;
+            font-size: 13px;
         }
-
         .contact-item:last-child { margin-bottom: 0; }
+        .contact-icon { width: 16px; height: 16px; flex-shrink: 0; fill: rgba(255,255,255,0.7); }
 
-        .contact-icon {
-            width: 18px;
-            height: 18px;
-            flex-shrink: 0;
-            fill: var(--color-white);
-        }
-
-        /* Education */
-        .education-item { margin-bottom: 15px; }
+        .education-item { margin-bottom: 12px; }
         .education-item:last-child { margin-bottom: 0; }
+        .degree { font-size: 14px; font-weight: 700; margin-bottom: 4px; }
+        .school { color: var(--color-sidebar-muted); font-size: 12px; }
+        .education-dates { color: var(--color-sidebar-muted); font-size: 12px; }
 
-        .degree {
-            font-size: 14px;
-            font-weight: 700;
-            margin-bottom: 5px;
-        }
-
-        .school {
-            color: var(--color-sidebar-muted);
-            font-weight: 500;
-            font-size: 13px;
-        }
-
-        .education-dates {
-            color: var(--color-sidebar-muted);
-            font-weight: 500;
-            font-size: 13px;
-        }
-
-        /* Languages */
-        .lang-item { margin-bottom: 10px; }
+        .lang-item { margin-bottom: 8px; font-size: 13px; }
         .lang-item:last-child { margin-bottom: 0; }
         .lang-level { color: var(--color-sidebar-muted); }
 
-        /* Interests */
-        .interest-item { margin-bottom: 10px; }
+        .interest-item { margin-bottom: 8px; font-size: 13px; }
         .interest-item:last-child { margin-bottom: 0; }
 
-        /* ======= Donate Banner ======= */
-        .donate-banner {
-            padding: 0;
-        }
-
-        .donate-banner a {
-            display: block;
-            background: #FBB03B;
-            color: #000080;
-            font-weight: 700;
-            text-decoration: none;
-            font-size: 14px;
-            padding: 14px 30px;
-            text-align: center;
-            transition: background 0.3s;
-        }
-
-        .donate-banner a:hover {
-            background: #e09a2a;
-            text-decoration: none;
-            color: #000080;
-        }
-
-        /* ======= Footer ======= */
         .cv-footer {
             max-width: var(--max-width);
             margin: 0 auto;
-            padding: 30px;
-            padding-top: 60px;
+            padding: 28px 20px;
+            padding-top: 48px;
             text-align: center;
-            color: var(--color-text);
-            font-size: 13px;
-            line-height: 1.6;
+            color: var(--color-text-muted);
+            font-size: 12px;
+            line-height: 1.8;
         }
+        .cv-footer a { font-weight: 500; color: var(--color-primary-dark); }
 
-        .cv-footer a {
-            font-weight: 500;
-        }
-
-        /* ======= Responsive ======= */
         @media (max-width: 767px) {
-            body { padding: 15px; }
-
-            .cv-wrapper {
-                grid-template-columns: 1fr;
-            }
-
-            .sidebar {
-                min-height: auto;
-                order: -1;
-            }
-
-            .main-content {
-                padding: 30px;
-                order: 0;
-            }
-
-            .experience-header {
-                flex-direction: column;
-            }
-
-            .time {
-                margin-left: 0;
-                margin-top: 4px;
-            }
+            body { padding: 12px; }
+            .cv-wrapper { grid-template-columns: 1fr; }
+            .sidebar { min-height: auto; order: -1; }
+            .main-content { padding: 32px 24px; order: 0; }
+            .experience-header { flex-direction: column; gap: 2px; }
         }
 
-        /* ======= Print ======= */
         @media print {
             body { padding: 0; background: white; font-size: 12px; }
-
-            .cv-wrapper {
-                box-shadow: none;
-                max-width: 100%;
-            }
-
-            .sidebar { background: var(--color-primary) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .profile { background: var(--color-sidebar-overlay) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .section { margin-bottom: 30px; }
-            .main-content { padding: 30px; }
-            .cv-footer { padding-top: 20px; }
-
+            .cv-wrapper { box-shadow: none; max-width: 100%; }
+            .main-content { background: white; }
+            .sidebar { background: var(--color-sidebar) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            .section { margin-bottom: 24px; }
+            .main-content { padding: 28px; }
             a { text-decoration: none !important; }
             .donate-banner { display: none; }
         }
@@ -379,12 +308,9 @@
 <div class="cv-wrapper">
     <main class="main-content">
 
-        <!-- Career Profile -->
         <section class="section">
             <h2 class="section-title">
-                <span class="section-icon">
-                    <svg viewBox="0 0 448 512"><path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512H418.3c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304H178.3z"/></svg>
-                </span>
+                <span class="section-icon"><svg viewBox="0 0 448 512"><path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512H418.3c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304H178.3z"/></svg></span>
                 Who am I
             </h2>
             <div class="summary">
@@ -395,16 +321,11 @@
             </div>
         </section>
 
-        <!-- Experience -->
         <section class="section">
             <h2 class="section-title">
-                <span class="section-icon">
-                    <svg viewBox="0 0 512 512"><path d="M184 48H328c4.4 0 8 3.6 8 8V96H176V56c0-4.4 3.6-8 8-8zm-56 8V96H64C28.7 96 0 124.7 0 160v96H192 320 512V160c0-35.3-28.7-64-64-64H384V56c0-30.9-25.1-56-56-56H184c-30.9 0-56 25.1-56 56zM512 288H320v32c0 17.7-14.3 32-32 32H224c-17.7 0-32-14.3-32-32V288H0V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V288z"/></svg>
-                </span>
+                <span class="section-icon"><svg viewBox="0 0 512 512"><path d="M184 48H328c4.4 0 8 3.6 8 8V96H176V56c0-4.4 3.6-8 8-8zm-56 8V96H64C28.7 96 0 124.7 0 160v96H192 320 512V160c0-35.3-28.7-64-64-64H384V56c0-30.9-25.1-56-56-56H184c-30.9 0-56 25.1-56 56zM512 288H320v32c0 17.7-14.3 32-32 32H224c-17.7 0-32-14.3-32-32V288H0V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V288z"/></svg></span>
                 Experience
             </h2>
-
-            <!-- NO military service on English pages -->
 
             <div class="experience-item">
                 <div class="experience-header">
@@ -412,16 +333,14 @@
                     <span class="time">May 2021 - April 2025</span>
                 </div>
                 <div class="company">Ledger</div>
-                <div class="details">
-                    <ul>
-                        <li>Designed and maintained production infrastructure for a cryptocurrency SaaS platform serving millions of users</li>
-                        <li>Implemented infrastructure-as-code practices using Terraform and policy-as-code frameworks for SaaS environments</li>
-                        <li>Managed Kubernetes deployments on AWS EKS with Helm charts and ArgoCD/Spinnaker for continuous delivery</li>
-                        <li>Built comprehensive monitoring solutions with Prometheus and Grafana for real-time system observability</li>
-                        <li>Optimized CI/CD pipelines achieving faster, more reliable deployment cycles with reduced failure rates</li>
-                        <li>Conducted performance analysis and troubleshooting of high-load distributed systems</li>
-                    </ul>
-                </div>
+                <div class="details"><ul>
+                    <li>Designed and maintained production infrastructure for a cryptocurrency SaaS platform serving millions of users</li>
+                    <li>Implemented infrastructure-as-code practices using Terraform and policy-as-code frameworks for SaaS environments</li>
+                    <li>Managed Kubernetes deployments on AWS EKS with Helm charts and ArgoCD/Spinnaker for continuous delivery</li>
+                    <li>Built comprehensive monitoring solutions with Prometheus and Grafana for real-time system observability</li>
+                    <li>Optimized CI/CD pipelines achieving faster, more reliable deployment cycles with reduced failure rates</li>
+                    <li>Conducted performance analysis and troubleshooting of high-load distributed systems</li>
+                </ul></div>
             </div>
 
             <div class="experience-item">
@@ -430,14 +349,12 @@
                     <span class="time">August 2019 - May 2021</span>
                 </div>
                 <div class="company">Ledger</div>
-                <div class="details">
-                    <ul>
-                        <li>Managed full AWS infrastructure including EKS clusters, networking, and security configurations</li>
-                        <li>Deployed and maintained Kubernetes workloads using Helm, implementing best practices for scaling</li>
-                        <li>Automated infrastructure provisioning with Terraform, Chef, and Ansible/SaltStack for consistent environments</li>
-                        <li>Collaborated with development teams to establish DevOps workflows and deployment standards</li>
-                    </ul>
-                </div>
+                <div class="details"><ul>
+                    <li>Managed full AWS infrastructure including EKS clusters, networking, and security configurations</li>
+                    <li>Deployed and maintained Kubernetes workloads using Helm, implementing best practices for scaling</li>
+                    <li>Automated infrastructure provisioning with Terraform, Chef, and Ansible/SaltStack for consistent environments</li>
+                    <li>Collaborated with development teams to establish DevOps workflows and deployment standards</li>
+                </ul></div>
             </div>
 
             <div class="experience-item">
@@ -446,13 +363,11 @@
                     <span class="time">November 2022 - August 2025</span>
                 </div>
                 <div class="company">Astroquirks</div>
-                <div class="details">
-                    <ul>
-                        <li>Built and maintained validator infrastructure for Tendermint/Cosmos-based blockchains (Osmosis, Stargaze)</li>
-                        <li>Designed full technical stack for high-availability blockchain node operation with 99.9% uptime</li>
-                        <li>Implemented monitoring, alerting, and auto-recovery systems for critical infrastructure</li>
-                    </ul>
-                </div>
+                <div class="details"><ul>
+                    <li>Built and maintained validator infrastructure for Tendermint/Cosmos-based blockchains (Osmosis, Stargaze)</li>
+                    <li>Designed full technical stack for high-availability blockchain node operation with 99.9% uptime</li>
+                    <li>Implemented monitoring, alerting, and auto-recovery systems for critical infrastructure</li>
+                </ul></div>
             </div>
 
             <div class="experience-item">
@@ -461,13 +376,11 @@
                     <span class="time">October 2013 - October 2018</span>
                 </div>
                 <div class="company">PortaOne, Kyiv</div>
-                <div class="details">
-                    <ul>
-                        <li>Provided L3/L4 support for VoIP billing systems in production environments</li>
-                        <li>Managed complex software deployments and system integrations for global enterprise clients</li>
-                        <li>Established processes and standards for collaboration between Development, QA, and Product Management</li>
-                    </ul>
-                </div>
+                <div class="details"><ul>
+                    <li>Provided L3/L4 support for VoIP billing systems in production environments</li>
+                    <li>Managed complex software deployments and system integrations for global enterprise clients</li>
+                    <li>Established processes and standards for collaboration between Development, QA, and Product Management</li>
+                </ul></div>
             </div>
 
             <div class="experience-item">
@@ -476,13 +389,11 @@
                     <span class="time">October 2008 - October 2013</span>
                 </div>
                 <div class="company">PortaOne, Kyiv</div>
-                <div class="details">
-                    <ul>
-                        <li>Advanced Linux/FreeBSD administration and troubleshooting of geo-redundant clustered systems</li>
-                        <li>Executed complex maintenance scenarios, software upgrades, and system migrations with minimal downtime</li>
-                        <li>Provided on-site technical consulting and installations for clients worldwide</li>
-                    </ul>
-                </div>
+                <div class="details"><ul>
+                    <li>Advanced Linux/FreeBSD administration and troubleshooting of geo-redundant clustered systems</li>
+                    <li>Executed complex maintenance scenarios, software upgrades, and system migrations with minimal downtime</li>
+                    <li>Provided on-site technical consulting and installations for clients worldwide</li>
+                </ul></div>
             </div>
 
             <div class="experience-item">
@@ -508,12 +419,9 @@
             </div>
         </section>
 
-        <!-- Skills -->
         <section class="section">
             <h2 class="section-title">
-                <span class="section-icon">
-                    <svg viewBox="0 0 512 512"><path d="M156.6 384.9L125.7 354c-8.5-8.5-11.5-20.8-7.7-32.2c3-8.9 7.7-17.4 13.9-25.2L48.5 213c-11.3-11.3-11.3-29.6 0-40.8l57.4-56.7c11.3-11.3 29.5-11.3 40.8 0l83.5 83.5c7.8-6.1 16.3-10.8 25.2-13.7c11.4-3.9 23.7-.8 32.2 7.7l30.9 30.9c5.7 5.7 8.7 13.5 8.4 21.6c19.4 14.6 34.5 34.4 43.5 57.5H480c17.7 0 32-14.3 32-32V64c0-17.7-14.3-32-32-32H64C46.3 32 32 46.3 32 64V352c0 17.7 14.3 32 32 32h92.5zM256 224a64 64 0 1 1 0 128 64 64 0 1 1 0-128zm-43.3 203.3l-20.6-20.6-76.2 76.2c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l76.2-76.2-20.6-20.6c-1.3-1.3-2.5-2.7-3.6-4.1zM393.4 307.2l-39.6-39.6c-3.3 5.7-7.2 11-11.7 15.5s-9.9 8.4-15.5 11.7l39.6 39.6 27.1-27.1z"/></svg>
-                </span>
+                <span class="section-icon"><svg viewBox="0 0 512 512"><path d="M156.6 384.9L125.7 354c-8.5-8.5-11.5-20.8-7.7-32.2c3-8.9 7.7-17.4 13.9-25.2L48.5 213c-11.3-11.3-11.3-29.6 0-40.8l57.4-56.7c11.3-11.3 29.5-11.3 40.8 0l83.5 83.5c7.8-6.1 16.3-10.8 25.2-13.7c11.4-3.9 23.7-.8 32.2 7.7l30.9 30.9c5.7 5.7 8.7 13.5 8.4 21.6c19.4 14.6 34.5 34.4 43.5 57.5H480c17.7 0 32-14.3 32-32V64c0-17.7-14.3-32-32-32H64C46.3 32 32 46.3 32 64V352c0 17.7 14.3 32 32 32h92.5zM256 224a64 64 0 1 1 0 128 64 64 0 1 1 0-128zm-43.3 203.3l-20.6-20.6-76.2 76.2c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l76.2-76.2-20.6-20.6c-1.3-1.3-2.5-2.7-3.6-4.1zM393.4 307.2l-39.6-39.6c-3.3 5.7-7.2 11-11.7 15.5s-9.9 8.4-15.5 11.7l39.6 39.6 27.1-27.1z"/></svg></span>
                 Technical Skills
             </h2>
 
@@ -548,44 +456,20 @@
     </main>
 
     <aside class="sidebar">
-        <!-- Profile -->
         <div class="profile">
             <img class="profile-photo" src="profile.png" alt="Iurii Klekovkin" width="120" height="120">
             <h1 class="name">Iurii Klekovkin</h1>
             <p class="tagline">Site Reliability Engineer · DevOps Engineer</p>
         </div>
-
-        <!-- Language toggle -->
-        <div class="lang-toggle">
-            <a href="sre-ua.html">UA</a> | <span class="active">EN</span>
-        </div>
-
-        <!-- Donate Banner -->
-        <div class="donate-banner">
-            <a href="donate.html">Support UAF / Підтримати ЗСУ</a>
-        </div>
-
-        <!-- Contact -->
+        <div class="lang-toggle"><a href="sre-ua.html">UA</a> | <span class="active">EN</span></div>
+        <div class="donate-banner"><a href="donate.html">Support UAF / Підтримати ЗСУ</a></div>
         <div class="sidebar-block">
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 512 512"><path d="M48 64C21.5 64 0 85.5 0 112c0 15.1 7.1 29.3 19.2 38.4L236.8 313.6c11.4 8.5 27 8.5 38.4 0L492.8 150.4c12.1-9.1 19.2-23.3 19.2-38.4c0-26.5-21.5-48-48-48H48zM0 176V384c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V176L294.4 339.2c-22.8 17.1-54 17.1-76.8 0L0 176z"/></svg>
-                <a href="mailto:iurii@klekovkin.com.ua">iurii@klekovkin.com.ua</a>
-            </div>
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 512 512"><path d="M164.9 24.6c-7.7-18.6-28-28.5-47.4-23.2l-88 24C12.1 30.2 0 46 0 64C0 311.4 200.6 512 448 512c18 0 33.8-12.1 38.6-29.5l24-88c5.3-19.4-4.6-39.7-23.2-47.4l-96-40c-16.3-6.8-35.2-2.1-46.3 11.6L304.7 368C234.3 334.7 177.3 277.7 144 207.3L193.3 167c13.7-11.2 18.4-30 11.6-46.3l-40-96z"/></svg>
-                <a href="tel:+380937791847">+380 93 779 1847</a>
-            </div>
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 448 512"><path d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg>
-                <a href="https://www.linkedin.com/in/klekovkin">in/klekovkin</a>
-            </div>
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 496 512"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.8-14.9-112.8-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/></svg>
-                <a href="https://github.com/depomytymoped">depomytymoped</a>
-            </div>
+            <h2 class="sidebar-block-title">Contact</h2>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 512 512"><path d="M48 64C21.5 64 0 85.5 0 112c0 15.1 7.1 29.3 19.2 38.4L236.8 313.6c11.4 8.5 27 8.5 38.4 0L492.8 150.4c12.1-9.1 19.2-23.3 19.2-38.4c0-26.5-21.5-48-48-48H48zM0 176V384c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V176L294.4 339.2c-22.8 17.1-54 17.1-76.8 0L0 176z"/></svg><a href="mailto:iurii@klekovkin.com.ua">iurii@klekovkin.com.ua</a></div>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 512 512"><path d="M164.9 24.6c-7.7-18.6-28-28.5-47.4-23.2l-88 24C12.1 30.2 0 46 0 64C0 311.4 200.6 512 448 512c18 0 33.8-12.1 38.6-29.5l24-88c5.3-19.4-4.6-39.7-23.2-47.4l-96-40c-16.3-6.8-35.2-2.1-46.3 11.6L304.7 368C234.3 334.7 177.3 277.7 144 207.3L193.3 167c13.7-11.2 18.4-30 11.6-46.3l-40-96z"/></svg><a href="tel:+380937791847">+380 93 779 1847</a></div>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 448 512"><path d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg><a href="https://www.linkedin.com/in/klekovkin">in/klekovkin</a></div>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 496 512"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.8-14.9-112.8-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/></svg><a href="https://github.com/depomytymoped">depomytymoped</a></div>
         </div>
-
-        <!-- Education -->
         <div class="sidebar-block">
             <h2 class="sidebar-block-title">Education</h2>
             <div class="education-item">
@@ -594,16 +478,12 @@
                 <div class="education-dates">2001 - 2019</div>
             </div>
         </div>
-
-        <!-- Languages -->
         <div class="sidebar-block">
             <h2 class="sidebar-block-title">Languages</h2>
             <div class="lang-item">Ukrainian <span class="lang-level">(Native)</span></div>
             <div class="lang-item">English <span class="lang-level">(Professional)</span></div>
             <div class="lang-item">Russian <span class="lang-level">(Beginner)</span></div>
         </div>
-
-        <!-- Interests -->
         <div class="sidebar-block">
             <h2 class="sidebar-block-title">Interests</h2>
             <div class="interest-item">Continuous growth</div>

--- a/sre-ua.html
+++ b/sre-ua.html
@@ -7,7 +7,6 @@
     <meta name="description" content="CV Юрій Клековкін | Site Reliability Engineer | DevOps Engineer | Kubernetes, Terraform, AWS, EKS, CI/CD, ArgoCD, Prometheus, Grafana | Infrastructure as Code | Моніторинг та спостережуваність">
     <meta name="author" content="Iurii Klekovkin">
 
-    <!-- Open Graph -->
     <meta property="og:title" content="Юрій Клековкін — SRE / DevOps CV">
     <meta property="og:description" content="Site Reliability Engineer · DevOps Engineer">
     <meta property="og:type" content="profile">
@@ -17,27 +16,44 @@
     <link rel="icon" type="image/png" href="favicon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700;900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700;900&family=Roboto+Slab:wght@400;500;600;700&display=swap" rel="stylesheet">
 
     <style>
-        /* ======= Custom Properties ======= */
         :root {
-            --color-primary: #42A8C0;
-            --color-primary-dark: #2d7788;
-            --color-primary-darker: #1a454f;
-            --color-text: #545E6C;
-            --color-text-dark: #3F4650;
-            --color-text-muted: #97AAC3;
-            --color-bg: #f5f5f5;
-            --color-white: #fff;
-            --color-skill-bar: #7bc2d3;
-            --color-sidebar-overlay: rgba(0, 0, 0, 0.2);
-            --color-sidebar-muted: rgba(255, 255, 255, 0.6);
-            --sidebar-width: 240px;
-            --max-width: 960px;
+            --color-primary: #2A9D8F;
+            --color-primary-dark: #1E7A6E;
+            --color-primary-darker: #145650;
+            --color-text: #3B4252;
+            --color-text-dark: #2E3440;
+            --color-text-muted: #8B95A5;
+            --color-bg: #F5F5F5;
+            --color-white: #FFFFFF;
+            --color-skill-bar: #6EC6B8;
+            --color-sidebar: #264653;
+            --color-sidebar-overlay: rgba(0, 0, 0, 0.15);
+            --color-sidebar-muted: rgba(255, 255, 255, 0.55);
+            --color-donate-bg: #E76F51;
+            --color-donate-hover: #D45A3C;
+            --sidebar-width: 250px;
+            --max-width: 980px;
         }
 
-        /* ======= Reset & Base ======= */
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --color-bg: #1A1D24;
+                --color-white: #22262E;
+                --color-text: #D8DEE9;
+                --color-text-dark: #ECEFF4;
+                --color-text-muted: #6B7894;
+                --color-primary: #56C4B4;
+                --color-primary-dark: #7AD4C8;
+                --color-primary-darker: #A0E4DA;
+                --color-skill-bar: #56C4B4;
+                --color-sidebar: #161920;
+                --color-sidebar-overlay: rgba(0, 0, 0, 0.3);
+            }
+        }
+
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
         body {
@@ -45,43 +61,43 @@
             color: var(--color-text);
             background: var(--color-bg);
             font-size: 14px;
-            line-height: 1.5;
+            line-height: 1.6;
             padding: 30px;
             -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
         }
 
-        h1, h2, h3, h4, h5, h6 { font-weight: 700; }
-        a { color: var(--color-primary-dark); transition: color 0.3s; }
+        h1, h2, h3 { font-family: 'Roboto Slab', 'Georgia', serif; }
+        a { color: var(--color-primary-dark); text-decoration: none; transition: color 0.2s; }
         a:hover { color: var(--color-primary-darker); }
         ul { list-style: none; }
         img { max-width: 100%; height: auto; }
 
-        /* ======= Layout ======= */
         .cv-wrapper {
             max-width: var(--max-width);
             margin: 0 auto;
             display: grid;
             grid-template-columns: 1fr var(--sidebar-width);
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+            overflow: hidden;
         }
 
-        /* ======= Main Content ======= */
         .main-content {
             background: var(--color-white);
-            padding: 60px;
+            padding: 52px 56px;
             order: -1;
         }
 
-        .section { margin-bottom: 60px; page-break-inside: avoid; }
+        .section { margin-bottom: 48px; page-break-inside: avoid; }
         .section:last-child { margin-bottom: 0; }
 
         .section-title {
             text-transform: uppercase;
-            font-size: 20px;
-            font-weight: 500;
+            font-size: 18px;
+            font-weight: 600;
             color: var(--color-primary-dark);
             margin-bottom: 20px;
+            padding-bottom: 10px;
+            border-bottom: 2px solid var(--color-primary);
             display: flex;
             align-items: center;
             gap: 10px;
@@ -90,7 +106,7 @@
         .section-icon {
             width: 30px;
             height: 30px;
-            background: var(--color-primary-dark);
+            background: var(--color-primary);
             border-radius: 50%;
             display: inline-flex;
             align-items: center;
@@ -98,18 +114,18 @@
             flex-shrink: 0;
         }
 
-        .section-icon svg {
-            width: 14px;
-            height: 14px;
-            fill: var(--color-white);
-        }
+        .section-icon svg { width: 14px; height: 14px; fill: #fff; }
 
-        /* ======= Summary ======= */
-        .summary p { margin-bottom: 1em; }
+        .summary { font-size: 14px; line-height: 1.75; color: var(--color-text); }
+        .summary p { margin-bottom: 0.9em; }
         .summary p:last-child { margin-bottom: 0; }
+        .summary strong { color: var(--color-text-dark); font-weight: 700; }
 
-        /* ======= Experience ======= */
-        .experience-item { margin-bottom: 30px; }
+        .experience-item {
+            margin-bottom: 28px;
+            padding-left: 16px;
+            border-left: 3px solid var(--color-primary);
+        }
         .experience-item:last-child { margin-bottom: 0; }
 
         .experience-header {
@@ -117,287 +133,207 @@
             justify-content: space-between;
             align-items: baseline;
             margin-bottom: 2px;
+            gap: 12px;
         }
 
         .job-title {
             color: var(--color-text-dark);
             font-size: 16px;
-            font-weight: 500;
+            font-weight: 600;
         }
 
         .time {
             color: var(--color-text-muted);
             white-space: nowrap;
-            margin-left: 10px;
+            font-size: 13px;
         }
 
         .company {
-            color: var(--color-text-muted);
-            margin-bottom: 10px;
+            color: var(--color-primary-dark);
+            font-size: 13px;
+            font-weight: 500;
+            margin-bottom: 8px;
         }
 
-        .details p { margin-bottom: 0.8em; }
+        .details { color: var(--color-text); font-size: 13px; line-height: 1.65; }
+        .details p { margin-bottom: 0.7em; }
         .details p:last-child { margin-bottom: 0; }
-        .details ul { list-style: disc; margin-left: 20px; margin-bottom: 0.8em; }
+        .details ul { list-style: disc; margin-left: 18px; margin-bottom: 0.7em; }
         .details ul:last-child { margin-bottom: 0; }
-        .details li { margin-bottom: 0.3em; }
+        .details li { margin-bottom: 3px; }
 
-        /* ======= Military Service (collapsible) ======= */
         .military-toggle {
             background: none;
             border: 1px solid var(--color-primary);
             color: var(--color-primary-dark);
-            font-family: inherit;
-            font-size: 14px;
+            font-size: 13px;
             font-weight: 500;
-            padding: 8px 16px;
+            padding: 6px 16px;
             border-radius: 4px;
             cursor: pointer;
-            margin-bottom: 30px;
+            margin-bottom: 28px;
             transition: background 0.2s, color 0.2s;
         }
+        .military-toggle:hover { background: var(--color-primary); color: #fff; }
+        .military-details { display: none; margin-bottom: 28px; }
+        .military-details.open { display: block; }
 
-        .military-toggle:hover {
-            background: var(--color-primary);
-            color: var(--color-white);
+        .skill-item { margin-bottom: 15px; overflow: hidden; }
+        .skill-name { font-size: 14px; font-weight: 500; margin-bottom: 6px; color: var(--color-text-dark); }
+        .skill-bar { height: 10px; background: var(--color-bg); width: 100%; border-radius: 5px; }
+        .skill-bar-inner {
+            height: 10px;
+            background: var(--color-skill-bar);
+            border-radius: 5px;
+            width: 0;
+            animation: grow-bar 0.8s ease-out forwards;
         }
+        @keyframes grow-bar { to { width: var(--level); } }
 
-        .military-details {
-            display: none;
-            margin-bottom: 30px;
-        }
-
-        .military-details.open {
-            display: block;
-        }
-
-        /* ======= Skills ======= */
-        /* Technical skills list */
-        .tech-skills { margin-top: 30px; }
-        .tech-skills h3 {
-            font-size: 14px;
-            font-weight: 700;
-            color: var(--color-text-dark);
-            margin-bottom: 8px;
-        }
-        .tech-skills ul {
-            list-style: none;
-            margin-bottom: 12px;
-        }
+        .tech-skills { margin-top: 28px; }
+        .tech-skills h3 { font-size: 13px; font-weight: 600; color: var(--color-text-dark); margin-bottom: 6px; }
+        .tech-skills ul { list-style: none; margin-bottom: 12px; }
         .tech-skills li {
-            margin-bottom: 4px;
-            padding-left: 16px;
+            margin-bottom: 3px;
+            padding-left: 14px;
             position: relative;
+            font-size: 13px;
         }
         .tech-skills li::before {
             content: "·";
             position: absolute;
             left: 4px;
             font-weight: 700;
+            color: var(--color-primary);
         }
 
-        /* ======= Sidebar ======= */
         .sidebar {
-            background: var(--color-primary);
-            color: var(--color-white);
+            background: var(--color-sidebar);
+            color: #fff;
             min-height: 800px;
         }
 
-        .sidebar a { color: var(--color-white); text-decoration: none; }
-        .sidebar a:hover { text-decoration: underline; color: var(--color-white); }
+        .sidebar a { color: #fff; text-decoration: none; }
+        .sidebar a:hover { text-decoration: underline; }
 
-        /* Profile */
         .profile {
-            padding: 30px;
+            padding: 36px 28px 28px;
             background: var(--color-sidebar-overlay);
             text-align: center;
         }
 
         .profile-photo {
-            width: 120px;
-            height: 120px;
+            width: 115px;
+            height: 115px;
             border-radius: 50%;
-            margin-bottom: 15px;
+            margin-bottom: 16px;
+            border: 3px solid rgba(255,255,255,0.2);
         }
 
         .profile .name {
-            font-size: 32px;
-            font-weight: 900;
-            margin-bottom: 10px;
+            font-size: 24px;
+            font-weight: 700;
+            margin-bottom: 8px;
         }
 
         .profile .tagline {
             color: var(--color-sidebar-muted);
-            font-size: 16px;
-            font-weight: 400;
+            font-size: 13px;
+            font-weight: 300;
         }
 
-        /* Sidebar blocks */
-        .sidebar-block {
-            padding: 30px;
-        }
-
-        .sidebar-block-title {
-            text-transform: uppercase;
-            font-size: 16px;
-            font-weight: 700;
-            margin-bottom: 15px;
-        }
-
-        /* Language toggle */
         .lang-toggle {
-            padding: 10px 30px;
+            padding: 10px 28px;
             text-align: center;
             font-size: 13px;
             font-weight: 500;
         }
+        .lang-toggle a { opacity: 0.6; }
+        .lang-toggle a:hover { opacity: 1; }
+        .lang-toggle .active { opacity: 1; font-weight: 700; cursor: default; }
 
-        .lang-toggle a {
-            opacity: 0.7;
-        }
-
-        .lang-toggle a:hover {
-            opacity: 1;
-        }
-
-        .lang-toggle .active {
-            opacity: 1;
+        .donate-banner { padding: 0; }
+        .donate-banner a {
+            display: block;
+            background: var(--color-donate-bg);
+            color: #fff;
             font-weight: 700;
+            font-size: 13px;
+            padding: 14px 28px;
+            text-align: center;
             text-decoration: none;
-            cursor: default;
+            transition: background 0.2s;
+        }
+        .donate-banner a:hover { background: var(--color-donate-hover); text-decoration: none; }
+
+        .sidebar-block { padding: 24px 28px; }
+        .sidebar-block-title {
+            text-transform: uppercase;
+            font-size: 13px;
+            font-weight: 700;
+            margin-bottom: 14px;
+            letter-spacing: 0.5px;
         }
 
-        /* Contact */
         .contact-item {
-            margin-bottom: 15px;
+            margin-bottom: 12px;
             display: flex;
             align-items: center;
             gap: 8px;
             word-break: break-word;
+            font-size: 13px;
         }
-
         .contact-item:last-child { margin-bottom: 0; }
+        .contact-icon { width: 16px; height: 16px; flex-shrink: 0; fill: rgba(255,255,255,0.7); }
 
-        .contact-icon {
-            width: 18px;
-            height: 18px;
-            flex-shrink: 0;
-            fill: var(--color-white);
-        }
-
-        /* Education */
-        .education-item { margin-bottom: 15px; }
+        .education-item { margin-bottom: 12px; }
         .education-item:last-child { margin-bottom: 0; }
+        .degree { font-size: 14px; font-weight: 700; margin-bottom: 4px; }
+        .school { color: var(--color-sidebar-muted); font-size: 12px; }
+        .education-dates { color: var(--color-sidebar-muted); font-size: 12px; }
 
-        .degree {
-            font-size: 14px;
-            font-weight: 700;
-            margin-bottom: 5px;
-        }
-
-        .school {
-            color: var(--color-sidebar-muted);
-            font-weight: 500;
-            font-size: 13px;
-        }
-
-        .education-dates {
-            color: var(--color-sidebar-muted);
-            font-weight: 500;
-            font-size: 13px;
-        }
-
-        /* Languages */
-        .lang-item { margin-bottom: 10px; }
+        .lang-item { margin-bottom: 8px; font-size: 13px; }
         .lang-item:last-child { margin-bottom: 0; }
         .lang-level { color: var(--color-sidebar-muted); }
 
-        /* Interests */
-        .interest-item { margin-bottom: 10px; }
+        .interest-item { margin-bottom: 8px; font-size: 13px; }
         .interest-item:last-child { margin-bottom: 0; }
 
-        /* ======= Donate Banner ======= */
-        .donate-banner {
-            padding: 0;
-        }
-
-        .donate-banner a {
-            display: block;
-            background: #FBB03B;
-            color: #000080;
-            font-weight: 700;
-            text-decoration: none;
-            font-size: 14px;
-            padding: 14px 30px;
-            text-align: center;
-            transition: background 0.3s;
-        }
-
-        .donate-banner a:hover {
-            background: #e09a2a;
-            text-decoration: none;
-            color: #000080;
-        }
-
-        /* ======= Footer ======= */
         .cv-footer {
             max-width: var(--max-width);
             margin: 0 auto;
-            padding: 30px;
-            padding-top: 60px;
+            padding: 28px 20px;
+            padding-top: 48px;
             text-align: center;
-            color: var(--color-text);
-            font-size: 13px;
-            line-height: 1.6;
+            color: var(--color-text-muted);
+            font-size: 12px;
+            line-height: 1.8;
         }
+        .cv-footer a { font-weight: 500; color: var(--color-primary-dark); }
 
-        .cv-footer a {
-            font-weight: 500;
-        }
-
-        /* ======= Responsive ======= */
         @media (max-width: 767px) {
-            body { padding: 15px; }
-
-            .cv-wrapper {
-                grid-template-columns: 1fr;
-            }
-
-            .sidebar {
-                min-height: auto;
-                order: -1;
-            }
-
-            .main-content {
-                padding: 30px;
-                order: 0;
-            }
-
-            .experience-header {
-                flex-direction: column;
-            }
-
-            .time {
-                margin-left: 0;
-                margin-top: 4px;
-            }
+            body { padding: 12px; }
+            .cv-wrapper { grid-template-columns: 1fr; }
+            .sidebar { min-height: auto; order: -1; }
+            .main-content { padding: 32px 24px; order: 0; }
+            .experience-header { flex-direction: column; gap: 2px; }
         }
 
-        /* ======= Print ======= */
+        @media (min-width: 992px) {
+            .skill-item { display: flex; align-items: center; gap: 0; }
+            .skill-name { width: 30%; flex-shrink: 0; margin-bottom: 0; }
+            .skill-bar { width: 70%; }
+        }
+
         @media print {
             body { padding: 0; background: white; font-size: 12px; }
-
-            .cv-wrapper {
-                box-shadow: none;
-                max-width: 100%;
-            }
-
-            .sidebar { background: var(--color-primary) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .profile { background: var(--color-sidebar-overlay) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-            .section { margin-bottom: 30px; }
-            .main-content { padding: 30px; }
-            .cv-footer { padding-top: 20px; }
-
+            .cv-wrapper { box-shadow: none; max-width: 100%; }
+            .main-content { background: white; }
+            .sidebar { background: var(--color-sidebar) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            .skill-bar { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            .skill-bar-inner { -webkit-print-color-adjust: exact; print-color-adjust: exact; animation: none; width: var(--level) !important; }
+            .section { margin-bottom: 24px; }
+            .main-content { padding: 28px; }
             a { text-decoration: none !important; }
             .donate-banner { display: none; }
             .military-toggle { display: none; }
@@ -410,12 +346,9 @@
 <div class="cv-wrapper">
     <main class="main-content">
 
-        <!-- Професійний профіль -->
         <section class="section">
             <h2 class="section-title">
-                <span class="section-icon">
-                    <svg viewBox="0 0 448 512"><path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512H418.3c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304H178.3z"/></svg>
-                </span>
+                <span class="section-icon"><svg viewBox="0 0 448 512"><path d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512H418.3c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304H178.3z"/></svg></span>
                 Хто я
             </h2>
             <div class="summary">
@@ -426,17 +359,13 @@
             </div>
         </section>
 
-        <!-- Досвід -->
         <section class="section">
             <h2 class="section-title">
-                <span class="section-icon">
-                    <svg viewBox="0 0 512 512"><path d="M184 48H328c4.4 0 8 3.6 8 8V96H176V56c0-4.4 3.6-8 8-8zm-56 8V96H64C28.7 96 0 124.7 0 160v96H192 320 512V160c0-35.3-28.7-64-64-64H384V56c0-30.9-25.1-56-56-56H184c-30.9 0-56 25.1-56 56zM512 288H320v32c0 17.7-14.3 32-32 32H224c-17.7 0-32-14.3-32-32V288H0V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V288z"/></svg>
-                </span>
+                <span class="section-icon"><svg viewBox="0 0 512 512"><path d="M184 48H328c4.4 0 8 3.6 8 8V96H176V56c0-4.4 3.6-8 8-8zm-56 8V96H64C28.7 96 0 124.7 0 160v96H192 320 512V160c0-35.3-28.7-64-64-64H384V56c0-30.9-25.1-56-56-56H184c-30.9 0-56 25.1-56 56zM512 288H320v32c0 17.7-14.3 32-32 32H224c-17.7 0-32-14.3-32-32V288H0V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V288z"/></svg></span>
                 Досвід
             </h2>
 
-            <!-- Military service — hidden by default -->
-            <button class="military-toggle" onclick="var d=document.querySelector('.military-details');d.classList.toggle('open');this.textContent=d.classList.contains('open')?'▾ Військова служба':'▸ Військова служба';">▸ Військова служба</button>
+            <button class="military-toggle" aria-expanded="false" onclick="var d=document.querySelector('.military-details');d.classList.toggle('open');var o=d.classList.contains('open');this.textContent=o?'▾ Військова служба':'▸ Військова служба';this.setAttribute('aria-expanded',o);">▸ Військова служба</button>
 
             <div class="military-details">
                 <div class="experience-item">
@@ -558,12 +487,9 @@
             </div>
         </section>
 
-        <!-- Навички -->
         <section class="section">
             <h2 class="section-title">
-                <span class="section-icon">
-                    <svg viewBox="0 0 512 512"><path d="M156.6 384.9L125.7 354c-8.5-8.5-11.5-20.8-7.7-32.2c3-8.9 7.7-17.4 13.9-25.2L48.5 213c-11.3-11.3-11.3-29.6 0-40.8l57.4-56.7c11.3-11.3 29.5-11.3 40.8 0l83.5 83.5c7.8-6.1 16.3-10.8 25.2-13.7c11.4-3.9 23.7-.8 32.2 7.7l30.9 30.9c5.7 5.7 8.7 13.5 8.4 21.6c19.4 14.6 34.5 34.4 43.5 57.5H480c17.7 0 32-14.3 32-32V64c0-17.7-14.3-32-32-32H64C46.3 32 32 46.3 32 64V352c0 17.7 14.3 32 32 32h92.5zM256 224a64 64 0 1 1 0 128 64 64 0 1 1 0-128zm-43.3 203.3l-20.6-20.6-76.2 76.2c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l76.2-76.2-20.6-20.6c-1.3-1.3-2.5-2.7-3.6-4.1zM393.4 307.2l-39.6-39.6c-3.3 5.7-7.2 11-11.7 15.5s-9.9 8.4-15.5 11.7l39.6 39.6 27.1-27.1z"/></svg>
-                </span>
+                <span class="section-icon"><svg viewBox="0 0 512 512"><path d="M156.6 384.9L125.7 354c-8.5-8.5-11.5-20.8-7.7-32.2c3-8.9 7.7-17.4 13.9-25.2L48.5 213c-11.3-11.3-11.3-29.6 0-40.8l57.4-56.7c11.3-11.3 29.5-11.3 40.8 0l83.5 83.5c7.8-6.1 16.3-10.8 25.2-13.7c11.4-3.9 23.7-.8 32.2 7.7l30.9 30.9c5.7 5.7 8.7 13.5 8.4 21.6c19.4 14.6 34.5 34.4 43.5 57.5H480c17.7 0 32-14.3 32-32V64c0-17.7-14.3-32-32-32H64C46.3 32 32 46.3 32 64V352c0 17.7 14.3 32 32 32h92.5zM256 224a64 64 0 1 1 0 128 64 64 0 1 1 0-128zm-43.3 203.3l-20.6-20.6-76.2 76.2c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l76.2-76.2-20.6-20.6c-1.3-1.3-2.5-2.7-3.6-4.1zM393.4 307.2l-39.6-39.6c-3.3 5.7-7.2 11-11.7 15.5s-9.9 8.4-15.5 11.7l39.6 39.6 27.1-27.1z"/></svg></span>
                 Технічні навички
             </h2>
 
@@ -598,44 +524,20 @@
     </main>
 
     <aside class="sidebar">
-        <!-- Profile -->
         <div class="profile">
-            <img class="profile-photo" src="profile.png" alt="Юрій Клековкін" width="120" height="120">
+            <img class="profile-photo" src="profile.png" alt="Юрій Клековкін" width="115" height="115">
             <h1 class="name">Юрій Клековкін</h1>
             <p class="tagline">Site Reliability Engineer · DevOps Engineer</p>
         </div>
-
-        <!-- Language toggle -->
-        <div class="lang-toggle">
-            <span class="active">UA</span> | <a href="sre-en.html">EN</a>
-        </div>
-
-        <!-- Donate Banner -->
-        <div class="donate-banner">
-            <a href="donate.html">Підтримати ЗСУ / Support UAF</a>
-        </div>
-
-        <!-- Контакти -->
+        <div class="lang-toggle"><span class="active">UA</span> | <a href="sre-en.html">EN</a></div>
+        <div class="donate-banner"><a href="donate.html">Підтримати ЗСУ / Support UAF</a></div>
         <div class="sidebar-block">
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 512 512"><path d="M48 64C21.5 64 0 85.5 0 112c0 15.1 7.1 29.3 19.2 38.4L236.8 313.6c11.4 8.5 27 8.5 38.4 0L492.8 150.4c12.1-9.1 19.2-23.3 19.2-38.4c0-26.5-21.5-48-48-48H48zM0 176V384c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V176L294.4 339.2c-22.8 17.1-54 17.1-76.8 0L0 176z"/></svg>
-                <a href="mailto:iurii@klekovkin.com.ua">iurii@klekovkin.com.ua</a>
-            </div>
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 512 512"><path d="M164.9 24.6c-7.7-18.6-28-28.5-47.4-23.2l-88 24C12.1 30.2 0 46 0 64C0 311.4 200.6 512 448 512c18 0 33.8-12.1 38.6-29.5l24-88c5.3-19.4-4.6-39.7-23.2-47.4l-96-40c-16.3-6.8-35.2-2.1-46.3 11.6L304.7 368C234.3 334.7 177.3 277.7 144 207.3L193.3 167c13.7-11.2 18.4-30 11.6-46.3l-40-96z"/></svg>
-                <a href="tel:+380937791847">+380 93 779 1847</a>
-            </div>
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 448 512"><path d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg>
-                <a href="https://www.linkedin.com/in/klekovkin">in/klekovkin</a>
-            </div>
-            <div class="contact-item">
-                <svg class="contact-icon" viewBox="0 0 496 512"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.8-14.9-112.8-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/></svg>
-                <a href="https://github.com/depomytymoped">depomytymoped</a>
-            </div>
+            <h2 class="sidebar-block-title">Контакти</h2>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 512 512"><path d="M48 64C21.5 64 0 85.5 0 112c0 15.1 7.1 29.3 19.2 38.4L236.8 313.6c11.4 8.5 27 8.5 38.4 0L492.8 150.4c12.1-9.1 19.2-23.3 19.2-38.4c0-26.5-21.5-48-48-48H48zM0 176V384c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V176L294.4 339.2c-22.8 17.1-54 17.1-76.8 0L0 176z"/></svg><a href="mailto:iurii@klekovkin.com.ua">iurii@klekovkin.com.ua</a></div>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 512 512"><path d="M164.9 24.6c-7.7-18.6-28-28.5-47.4-23.2l-88 24C12.1 30.2 0 46 0 64C0 311.4 200.6 512 448 512c18 0 33.8-12.1 38.6-29.5l24-88c5.3-19.4-4.6-39.7-23.2-47.4l-96-40c-16.3-6.8-35.2-2.1-46.3 11.6L304.7 368C234.3 334.7 177.3 277.7 144 207.3L193.3 167c13.7-11.2 18.4-30 11.6-46.3l-40-96z"/></svg><a href="tel:+380937791847">+380 93 779 1847</a></div>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 448 512"><path d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg><a href="https://www.linkedin.com/in/klekovkin">in/klekovkin</a></div>
+            <div class="contact-item"><svg class="contact-icon" viewBox="0 0 496 512"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.8-14.9-112.8-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/></svg><a href="https://github.com/depomytymoped">depomytymoped</a></div>
         </div>
-
-        <!-- Освіта -->
         <div class="sidebar-block">
             <h2 class="sidebar-block-title">Освіта</h2>
             <div class="education-item">
@@ -644,16 +546,12 @@
                 <div class="education-dates">2001 - 2019</div>
             </div>
         </div>
-
-        <!-- Мови -->
         <div class="sidebar-block">
             <h2 class="sidebar-block-title">Мови</h2>
             <div class="lang-item">Українська <span class="lang-level">(Рідна)</span></div>
             <div class="lang-item">Англійська <span class="lang-level">(Професійний)</span></div>
             <div class="lang-item">Російська <span class="lang-level">(Початковий)</span></div>
         </div>
-
-        <!-- Інтереси -->
         <div class="sidebar-block">
             <h2 class="sidebar-block-title">Інтереси</h2>
             <div class="interest-item">Безперервний розвиток</div>


### PR DESCRIPTION
## Summary
- Redesign all 6 CV pages (3 directions x 2 languages) with "Refined Original" design
- Roboto body + Roboto Slab headings, deeper teal palette (#2A9D8F), dark navy sidebar (#264653)
- Dark/light theme support via `prefers-color-scheme`
- Left teal accent border on experience items, rounded skill bars, coral donate banner (#E76F51)
- Consistent design across all pages: index.html, en.html, sre-ua/en.html, manager-ua/en.html

## Test plan
- [ ] Open all 6 pages in browser, verify consistent styling
- [ ] Toggle system dark/light mode, verify both themes render correctly
- [ ] Check mobile layout (767px breakpoint)
- [ ] Verify language toggles link correctly between UA/EN pairs
- [ ] Verify military toggle works on UA pages, absent on EN pages
- [ ] Print preview — donate banner hidden, skill bars visible